### PR TITLE
Support C++11 class-virt specifier for "class A final {}" cases.

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -178,6 +178,34 @@ class C : C::D, public E {
     (field_declaration_list)))
 
 =========================================
+Classes with final virt specifier
+=========================================
+
+class A final : public B {
+};
+
+class C final {};
+
+struct D final {};
+
+---
+
+(translation_unit
+  (class_specifier
+    (type_identifier)
+    (virtual_specifier)
+    (base_class_clause (type_identifier))
+    (field_declaration_list))
+  (class_specifier
+    (type_identifier)
+    (virtual_specifier)
+    (field_declaration_list))
+  (struct_specifier
+    (type_identifier)
+    (virtual_specifier)
+    (field_declaration_list)))
+
+=========================================
 Friend declarations
 =========================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -70,6 +70,7 @@ module.exports = grammar(C, {
         $._class_name,
         seq(
           optional($._class_name),
+          optional($.virtual_specifier),
           optional($.base_class_clause),
           $.field_declaration_list
         )
@@ -82,6 +83,7 @@ module.exports = grammar(C, {
         $._class_name,
         seq(
           optional($._class_name),
+          optional($.virtual_specifier),
           optional($.base_class_clause),
           $.field_declaration_list
         )
@@ -94,6 +96,7 @@ module.exports = grammar(C, {
         $._class_name,
         seq(
           optional($._class_name),
+          optional($.virtual_specifier),
           optional($.base_class_clause),
           $.field_declaration_list
         )
@@ -104,6 +107,10 @@ module.exports = grammar(C, {
       $._type_identifier,
       $.scoped_type_identifier,
       $.template_type
+    ),
+
+    virtual_specifier: $ => choice(
+      'final',
     ),
 
     base_class_clause: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2368,6 +2368,18 @@
                     "members": [
                       {
                         "type": "SYMBOL",
+                        "name": "virtual_specifier"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
                         "name": "base_class_clause"
                       },
                       {
@@ -2412,6 +2424,18 @@
                       {
                         "type": "SYMBOL",
                         "name": "_class_name"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "virtual_specifier"
                       },
                       {
                         "type": "BLANK"
@@ -4867,6 +4891,18 @@
                     "members": [
                       {
                         "type": "SYMBOL",
+                        "name": "virtual_specifier"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
                         "name": "base_class_clause"
                       },
                       {
@@ -4899,6 +4935,15 @@
         {
           "type": "SYMBOL",
           "name": "template_type"
+        }
+      ]
+    },
+    "virtual_specifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "final"
         }
       ]
     },


### PR DESCRIPTION
I'm doing some experimentation related to Mozilla's searchfox tool and it choked on [`class ServiceWorkerRegistrarSaveDataRunnable final : public Runnable`](https://searchfox.org/mozilla-central/source/dom/serviceworkers/ServiceWorkerRegistrar.cpp#824) in my experimentation so I thought I'd try my hand at a fix*.  It's okay if you'd rather not take random piece-meal patches like this and instead take a more comprehensive C++11 update/other.  I'm just happy to have this tool available and that it supports such great error recovery so small issues like this aren't a big deal!  Thanks for the amazing tool!

I've linked to the relevant docs in the first commit.  Note that http://www.nongnu.org/hcb/#class-virt-specifier which is one of the sources this repo links to cites "explicit" as a possible class-virt-specifier.  This is not consistent with what I found or the semantics I understand (https://en.cppreference.com/w/cpp/language/explicit).   Which is good, when I tried to add "explicit" and ran with an example like "class A explicit final", the type_qualifier rule ended up firing, causing the class_specifier to take only the _class_name sub-tree and then resulted in an ERROR, so it's good that's not legal.

`*` Note that the searchfox UI proper doesn't use tree-sitter.  All its semantics derive from a clang plugin.  I'm use tree-sitter as a higher-level prototyping helper on top of searchfox for prototyping things that would eventually go into the clang plugin or follow-on rust-based analyses later if they prove useful.