### PR TITLE
Add support for function virtual specifiers.

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -129,6 +129,48 @@ struct S {
       (compound_statement (return_statement (identifier)))))))
 
 =========================================
+Inline method definitions with overrides
+=========================================
+
+struct B : A {
+  int foo() override { return 2; }
+  int pho() final { return 3; }
+  int bar() const override { return 4; }
+  int baz() const final { return 5; }
+  int bag() const final override { return 6; }
+  int bah() const override final { return 7; }
+};
+
+---
+
+(translation_unit
+  (struct_specifier (type_identifier) (base_class_clause (type_identifier)) (field_declaration_list
+    (function_definition
+      (primitive_type)
+      (function_declarator (field_identifier) (parameter_list) (virtual_specifier))
+      (compound_statement (return_statement (number_literal))))
+    (function_definition
+      (primitive_type)
+      (function_declarator (field_identifier) (parameter_list) (virtual_specifier))
+      (compound_statement (return_statement (number_literal))))
+    (function_definition
+      (primitive_type)
+      (function_declarator (field_identifier) (parameter_list) (type_qualifier) (virtual_specifier))
+      (compound_statement (return_statement (number_literal))))
+    (function_definition
+      (primitive_type)
+      (function_declarator (field_identifier) (parameter_list) (type_qualifier) (virtual_specifier))
+      (compound_statement (return_statement (number_literal))))
+    (function_definition
+      (primitive_type)
+      (function_declarator (field_identifier) (parameter_list) (type_qualifier) (virtual_specifier) (virtual_specifier))
+      (compound_statement (return_statement (number_literal))))
+    (function_definition
+      (primitive_type)
+      (function_declarator (field_identifier) (parameter_list) (type_qualifier) (virtual_specifier) (virtual_specifier))
+      (compound_statement (return_statement (number_literal)))))))
+
+=========================================
 Constructor and destructor declarations
 =========================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -110,7 +110,8 @@ module.exports = grammar(C, {
     ),
 
     virtual_specifier: $ => choice(
-      'final',
+      'final', // the only legal value here for classes
+      'override' // legal for functions in addition to final, plus permutations.
     ),
 
     base_class_clause: $ => seq(
@@ -309,6 +310,7 @@ module.exports = grammar(C, {
       original,
       repeat(choice(
         $.type_qualifier,
+        $.virtual_specifier,
         $.noexcept,
         $.trailing_return_type
       ))
@@ -318,6 +320,7 @@ module.exports = grammar(C, {
       original,
       repeat(choice(
         $.type_qualifier,
+        $.virtual_specifier,
         $.noexcept,
         $.trailing_return_type
       ))

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "nan": "^2.10.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.13.1",
-    "tree-sitter-c": "tree-sitter/tree-sitter-c"
+    "tree-sitter-c": "^0.13.0",
+    "tree-sitter-cli": "^0.13.1"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1591,6 +1591,10 @@
               },
               {
                 "type": "SYMBOL",
+                "name": "virtual_specifier"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "noexcept"
               },
               {
@@ -1630,6 +1634,10 @@
               {
                 "type": "SYMBOL",
                 "name": "type_qualifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "virtual_specifier"
               },
               {
                 "type": "SYMBOL",
@@ -4973,6 +4981,10 @@
         {
           "type": "STRING",
           "value": "final"
+        },
+        {
+          "type": "STRING",
+          "value": "override"
         }
       ]
     },


### PR DESCRIPTION
In an attempt to expand on #6 and support override/final for functions
I've attempted some changes in this patch.

The relevant specs are:
https://en.cppreference.com/w/cpp/language/override
https://en.cppreference.com/w/cpp/language/final

Given the test input:
```
struct B : A {
  int foo() override { return 2; }
  int pho() final { return 3; }
  int bar() const override { return 4; }
  int baz() const final { return 5; }
  int bag() const final override { return 6; }
  int bah() const override final { return 7; }
};
```

The test results come out:
```
(translation_unit (struct_specifier (type_identifier) (base_class_clause (type_identifier)) (field_declaration_list
(function_definition (primitive_type) (function_declarator (field_identifier) (parameter_list)) (ERROR) (compound_statement (return_statement (number_literal))))
(function_definition (primitive_type) (function_declarator (field_identifier) (parameter_list)) (ERROR) (compound_statement (return_statement (number_literal))))
(function_definition (primitive_type) (function_declarator (field_identifier) (parameter_list) (type_qualifier)) (ERROR) (compound_statement (return_statement (number_literal))))
(function_definition (primitive_type) (function_declarator (field_identifier) (parameter_list) (type_qualifier)) (ERROR) (compound_statement (return_statement (number_literal))))
(function_definition (primitive_type) (function_declarator (field_identifier) (parameter_list) (type_qualifier)) (ERROR) (compound_statement (return_statement (number_literal))))
(function_definition (primitive_type) (function_declarator (field_identifier) (parameter_list) (type_qualifier)) (ERROR) (compound_statement (return_statement (number_literal)))))))
```

Perhaps most concerning is that the grammar.json loses its "word" directive.

In any event, I'd appreciate any pointers you could provide on making this
work.  (Also just making it work is okay by me too! ;)