### PR TITLE
Fix ctor/dtor with attributes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -321,7 +321,8 @@ module.exports = grammar(C, {
     constructor_or_destructor_definition: $ => seq(
       repeat(choice(
         $.storage_class_specifier,
-        $.type_qualifier
+        $.type_qualifier,
+        $.attribute_specifier
       )),
       prec(1, seq(
         optional($.virtual_function_specifier),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -878,6 +878,10 @@
               {
                 "type": "SYMBOL",
                 "name": "type_qualifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute_specifier"
               }
             ]
           }
@@ -898,6 +902,10 @@
               {
                 "type": "SYMBOL",
                 "name": "type_qualifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute_specifier"
               }
             ]
           }
@@ -929,6 +937,32 @@
             {
               "type": "SYMBOL",
               "name": "declaration_list"
+            }
+          ]
+        }
+      ]
+    },
+    "attribute_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__attribute__"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
             }
           ]
         }
@@ -1344,6 +1378,13 @@
               {
                 "type": "SYMBOL",
                 "name": "parameter_list"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "attribute_specifier"
+                }
               }
             ]
           }
@@ -1810,10 +1851,6 @@
             {
               "type": "STRING",
               "value": "const"
-            },
-            {
-              "type": "STRING",
-              "value": "restrict"
             },
             {
               "type": "STRING",
@@ -5781,6 +5818,10 @@
               {
                 "type": "SYMBOL",
                 "name": "type_qualifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute_specifier"
               }
             ]
           }


### PR DESCRIPTION
The generation is broken because of the patch to handle __attribute__ in tree-sitter-c.
So the goal of this patch is to fix the ambiguities.