### PR TITLE
Handle throw

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -107,3 +107,26 @@ void main() {
         (catch_clause
           (parameter_list)
           (compound_statement (comment)))))))
+
+===========================================
+Throw statements
+===========================================
+
+void main() {
+     throw e;
+     throw x + 1;
+     throw "exception";
+}
+
+---
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list))
+      (compound_statement
+        (throw_statement (identifier))
+        (throw_statement (math_expression (identifier) (number_literal)))
+        (throw_statement (string_literal)))))

--- a/grammar.js
+++ b/grammar.js
@@ -488,7 +488,8 @@ module.exports = grammar(C, {
     _statement: ($, original) => choice(
       original,
       $.for_range_loop,
-      $.try_statement
+      $.try_statement,
+      $.throw_statement,
     ),
 
     if_statement: $ => prec.right(seq(
@@ -524,6 +525,12 @@ module.exports = grammar(C, {
         $.initializer_list,
         ';'
       )
+    ),
+
+    throw_statement: $ => seq(
+      'throw',
+      optional($._expression),
+      ';'
     ),
 
     try_statement: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -321,7 +321,8 @@ module.exports = grammar(C, {
     constructor_or_destructor_definition: $ => seq(
       repeat(choice(
         $.storage_class_specifier,
-        $.type_qualifier
+        $.type_qualifier,
+        $.attribute_specifier
       )),
       prec(1, seq(
         optional($.virtual_function_specifier),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1854,6 +1854,10 @@
             },
             {
               "type": "STRING",
+              "value": "restrict"
+            },
+            {
+              "type": "STRING",
               "value": "volatile"
             },
             {
@@ -2778,6 +2782,10 @@
         {
           "type": "SYMBOL",
           "name": "try_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "throw_statement"
         }
       ]
     },
@@ -6448,6 +6456,31 @@
         {
           "type": "SYMBOL",
           "name": "_declarator"
+        }
+      ]
+    },
+    "throw_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "throw"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -878,6 +878,10 @@
               {
                 "type": "SYMBOL",
                 "name": "type_qualifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute_specifier"
               }
             ]
           }
@@ -898,6 +902,10 @@
               {
                 "type": "SYMBOL",
                 "name": "type_qualifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute_specifier"
               }
             ]
           }
@@ -929,6 +937,32 @@
             {
               "type": "SYMBOL",
               "name": "declaration_list"
+            }
+          ]
+        }
+      ]
+    },
+    "attribute_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__attribute__"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
             }
           ]
         }
@@ -1344,6 +1378,13 @@
               {
                 "type": "SYMBOL",
                 "name": "parameter_list"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "attribute_specifier"
+                }
               }
             ]
           }
@@ -1810,10 +1851,6 @@
             {
               "type": "STRING",
               "value": "const"
-            },
-            {
-              "type": "STRING",
-              "value": "restrict"
             },
             {
               "type": "STRING",
@@ -5781,6 +5818,10 @@
               {
                 "type": "SYMBOL",
                 "name": "type_qualifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute_specifier"
               }
             ]
           }


### PR DESCRIPTION
The goal of this patch is to handle to keyword "throw".
```cpp
void main() {
     throw e;
     throw x + 1;
     throw "exception";
}
```