### PR TITLE
Fix declaration in if/switch/while conditions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -565,10 +565,57 @@ module.exports = grammar(C, {
       $.throw_statement,
     ),
 
+    condition_declaration: $ => seq(
+      '(',
+      $._declaration_specifiers,
+      field('declarator', $._declarator),
+      choice(
+        seq(
+          '=',
+          field('default_value', $._expression),
+        ),
+        $.initializer_list,
+      ),
+      ')',
+    ),
+
+    init_statement: $ => seq(
+      '(',
+      choice(
+        field('initializer', $.declaration),
+        seq(field('initializer', optional(choice($._expression, $.comma_expression))), ';'),
+      ),
+      field('condition', optional($._expression)),
+      ')',
+    ),
+
+    switch_statement: $ => seq(
+      'switch',
+      field('condition', choice(
+        $.parenthesized_expression,
+        $.condition_declaration,
+        $.init_statement,
+      )),
+      field('body', $.compound_statement)
+    ),
+
+    while_statement: $ => seq(
+      'while',
+      field('condition', choice(
+        $.parenthesized_expression,
+        $.condition_declaration,
+      )),
+      field('body', $._statement)
+    ),
+
     if_statement: $ => prec.right(seq(
       'if',
       optional('constexpr'),
-      field('condition', $.parenthesized_expression),
+      field('condition', choice(
+        $.parenthesized_expression,
+        $.condition_declaration,
+        $.init_statement,
+      )),
       field('consequence', $._statement),
       optional(seq(
         'else',

--- a/grammar.js
+++ b/grammar.js
@@ -565,63 +565,58 @@ module.exports = grammar(C, {
       $.throw_statement,
     ),
 
-    condition_declaration: $ => seq(
-      '(',
-      $._declaration_specifiers,
-      field('declarator', $._declarator),
-      choice(
-        seq(
-          '=',
-          field('default_value', $._expression),
-        ),
-        $.initializer_list,
-      ),
-      ')',
-    ),
-
-    init_statement: $ => seq(
-      '(',
-      choice(
-        field('initializer', $.declaration),
-        seq(field('initializer', optional(choice($._expression, $.comma_expression))), ';'),
-      ),
-      field('condition', optional($._expression)),
-      ')',
-    ),
-
     switch_statement: $ => seq(
       'switch',
-      field('condition', choice(
-        $.parenthesized_expression,
-        $.condition_declaration,
-        $.init_statement,
-      )),
+      field('condition', $.condition_clause),
       field('body', $.compound_statement)
     ),
 
     while_statement: $ => seq(
       'while',
-      field('condition', choice(
-        $.parenthesized_expression,
-        $.condition_declaration,
-      )),
+      field('condition', $.condition_clause),
       field('body', $._statement)
     ),
 
     if_statement: $ => prec.right(seq(
       'if',
       optional('constexpr'),
-      field('condition', choice(
-        $.parenthesized_expression,
-        $.condition_declaration,
-        $.init_statement,
-      )),
+      field('condition', $.condition_clause),
       field('consequence', $._statement),
       optional(seq(
         'else',
         field('alternative', $._statement)
       ))
     )),
+
+    condition_clause: $ => seq(
+      '(',
+      choice(
+        seq(
+          field('initializer', optional(choice(
+            $.declaration,
+            $.expression_statement
+          ))),
+          field('value', choice(
+            $._expression,
+            $.comma_expression
+          )),
+        ),
+        field('value', alias($.condition_declaration, $.declaration))
+      ),
+      ')',
+    ),
+
+    condition_declaration: $ => seq(
+      $._declaration_specifiers,
+      field('declarator', $._declarator),
+      choice(
+        seq(
+          '=',
+          field('value', $._expression),
+        ),
+        field('value', $.initializer_list),
+      )
+    ),
 
     for_range_loop: $ => seq(
       'for',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4104,21 +4104,8 @@
             "type": "FIELD",
             "name": "condition",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "parenthesized_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "condition_declaration"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "init_statement"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "condition_clause"
             }
           },
           {
@@ -4168,21 +4155,8 @@
           "type": "FIELD",
           "name": "condition",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "parenthesized_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "condition_declaration"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "init_statement"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "condition_clause"
           }
         },
         {
@@ -4265,17 +4239,8 @@
           "type": "FIELD",
           "name": "condition",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "parenthesized_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "condition_declaration"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "condition_clause"
           }
         },
         {
@@ -8761,13 +8726,87 @@
         }
       ]
     },
-    "condition_declaration": {
+    "condition_clause": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
           "value": "("
         },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "initializer",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "declaration"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "expression_statement"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "value",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "comma_expression"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "value",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "condition_declaration"
+                },
+                "named": true,
+                "value": "declaration"
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "condition_declaration": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "SYMBOL",
           "name": "_declaration_specifiers"
@@ -8792,7 +8831,7 @@
                 },
                 {
                   "type": "FIELD",
-                  "name": "default_value",
+                  "name": "value",
                   "content": {
                     "type": "SYMBOL",
                     "name": "_expression"
@@ -8801,90 +8840,14 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "initializer_list"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        }
-      ]
-    },
-    "init_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
               "type": "FIELD",
-              "name": "initializer",
+              "name": "value",
               "content": {
                 "type": "SYMBOL",
-                "name": "declaration"
+                "name": "initializer_list"
               }
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "initializer",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "_expression"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "comma_expression"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
             }
           ]
-        },
-        {
-          "type": "FIELD",
-          "name": "condition",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": ")"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4104,8 +4104,21 @@
             "type": "FIELD",
             "name": "condition",
             "content": {
-              "type": "SYMBOL",
-              "name": "parenthesized_expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "parenthesized_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "condition_declaration"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "init_statement"
+                }
+              ]
             }
           },
           {
@@ -4155,8 +4168,21 @@
           "type": "FIELD",
           "name": "condition",
           "content": {
-            "type": "SYMBOL",
-            "name": "parenthesized_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parenthesized_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "condition_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "init_statement"
+              }
+            ]
           }
         },
         {
@@ -4239,8 +4265,17 @@
           "type": "FIELD",
           "name": "condition",
           "content": {
-            "type": "SYMBOL",
-            "name": "parenthesized_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parenthesized_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "condition_declaration"
+              }
+            ]
           }
         },
         {
@@ -8723,6 +8758,133 @@
         {
           "type": "STRING",
           "value": ";"
+        }
+      ]
+    },
+    "condition_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_declaration_specifiers"
+        },
+        {
+          "type": "FIELD",
+          "name": "declarator",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_declarator"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "FIELD",
+                  "name": "default_value",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "initializer_list"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "init_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "initializer",
+              "content": {
+                "type": "SYMBOL",
+                "name": "declaration"
+              }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "initializer",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "comma_expression"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": ";"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1356,6 +1356,64 @@
     }
   },
   {
+    "type": "condition_declaration",
+    "named": true,
+    "fields": {
+      "declarator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_declarator",
+            "named": true
+          }
+        ]
+      },
+      "default_value": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_type_specifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "initializer_list",
+          "named": true
+        },
+        {
+          "type": "storage_class_specifier",
+          "named": true
+        },
+        {
+          "type": "type_qualifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "conditional_expression",
     "named": true,
     "fields": {
@@ -2332,6 +2390,14 @@
         "required": true,
         "types": [
           {
+            "type": "condition_declaration",
+            "named": true
+          },
+          {
+            "type": "init_statement",
+            "named": true
+          },
+          {
             "type": "parenthesized_expression",
             "named": true
           }
@@ -2377,6 +2443,40 @@
           },
           {
             "type": "initializer_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "init_statement",
+    "named": true,
+    "fields": {
+      "condition": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "initializer": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "comma_expression",
+            "named": true
+          },
+          {
+            "type": "declaration",
             "named": true
           }
         ]
@@ -4077,6 +4177,14 @@
         "required": true,
         "types": [
           {
+            "type": "condition_declaration",
+            "named": true
+          },
+          {
+            "type": "init_statement",
+            "named": true
+          },
+          {
             "type": "parenthesized_expression",
             "named": true
           }
@@ -4879,6 +4987,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "condition_declaration",
+            "named": true
+          },
           {
             "type": "parenthesized_expression",
             "named": true

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1356,61 +1356,41 @@
     }
   },
   {
-    "type": "condition_declaration",
+    "type": "condition_clause",
     "named": true,
     "fields": {
-      "declarator": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_declarator",
-            "named": true
-          }
-        ]
-      },
-      "default_value": {
+      "initializer": {
         "multiple": false,
         "required": false,
         "types": [
           {
-            "type": "_expression",
+            "type": "declaration",
+            "named": true
+          },
+          {
+            "type": "expression_statement",
             "named": true
           }
         ]
       },
-      "type": {
+      "value": {
         "multiple": false,
         "required": true,
         "types": [
           {
-            "type": "_type_specifier",
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "comma_expression",
+            "named": true
+          },
+          {
+            "type": "declaration",
             "named": true
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "attribute_specifier",
-          "named": true
-        },
-        {
-          "type": "initializer_list",
-          "named": true
-        },
-        {
-          "type": "storage_class_specifier",
-          "named": true
-        },
-        {
-          "type": "type_qualifier",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -1482,6 +1462,20 @@
         "types": [
           {
             "type": "_type_specifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "initializer_list",
             "named": true
           }
         ]
@@ -2390,15 +2384,7 @@
         "required": true,
         "types": [
           {
-            "type": "condition_declaration",
-            "named": true
-          },
-          {
-            "type": "init_statement",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
+            "type": "condition_clause",
             "named": true
           }
         ]
@@ -2443,40 +2429,6 @@
           },
           {
             "type": "initializer_list",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "init_statement",
-    "named": true,
-    "fields": {
-      "condition": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "_expression",
-            "named": true
-          }
-        ]
-      },
-      "initializer": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "comma_expression",
-            "named": true
-          },
-          {
-            "type": "declaration",
             "named": true
           }
         ]
@@ -4177,15 +4129,7 @@
         "required": true,
         "types": [
           {
-            "type": "condition_declaration",
-            "named": true
-          },
-          {
-            "type": "init_statement",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
+            "type": "condition_clause",
             "named": true
           }
         ]
@@ -4988,11 +4932,7 @@
         "required": true,
         "types": [
           {
-            "type": "condition_declaration",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
+            "type": "condition_clause",
             "named": true
           }
         ]

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -370,7 +370,7 @@ int main() {
   (compound_statement
     (comment)
     (if_statement
-      (parenthesized_expression
+      (condition_clause
         (call_expression
           (template_function
             (identifier)
@@ -379,7 +379,7 @@ int main() {
       (compound_statement))
     (comment)
     (if_statement
-      (parenthesized_expression
+      (condition_clause
         (binary_expression
           (binary_expression (identifier) (identifier))
           (binary_expression (identifier) (identifier))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -80,12 +80,6 @@ T f() {
     return t;
 }
 
-void f() {
-  if (const int x = foo()) { }
-  if (const int x { foo() }) { }
-  if (const int x = foo(); x != 0) { }
-}
-
 ---
 
 (translation_unit
@@ -96,16 +90,30 @@ void f() {
       parameters: (parameter_list))
     body: (compound_statement
       (if_statement
-        condition: (parenthesized_expression
-          (template_function
+        condition: (condition_clause
+          value: (template_function
             name: (scoped_identifier
               namespace: (namespace_identifier)
               name: (identifier))
-          arguments: (template_argument_list
-            (type_descriptor type: (type_identifier)))))
+            arguments: (template_argument_list
+              (type_descriptor type: (type_identifier)))))
         consequence: (return_statement
           (pointer_expression argument: (identifier)))
-        alternative: (return_statement (identifier)))))
+        alternative: (return_statement (identifier))))))
+
+=====================================
+If statements with declarations
+====================================
+
+void f() {
+  if (const int x = foo()) { }
+  if (const int x { foo() }) { }
+  if (const int x = foo(); x != 0) { }
+}
+
+---
+
+(translation_unit
   (function_definition
     type: (primitive_type)
     declarator: (function_declarator
@@ -113,19 +121,32 @@ void f() {
       parameters: (parameter_list))
     body: (compound_statement
       (if_statement
-        condition: (condition_declaration
-          (type_qualifier) type: (primitive_type)
-          declarator: (identifier) default_value: (call_expression function: (identifier) arguments: (argument_list)))
+        condition: (condition_clause
+          value: (declaration
+            (type_qualifier)
+            type: (primitive_type)
+            declarator: (identifier)
+            value: (call_expression
+              function: (identifier)
+              arguments: (argument_list))))
         consequence: (compound_statement))
       (if_statement
-        condition: (condition_declaration
-          (type_qualifier) type: (primitive_type)
-          declarator: (identifier) (initializer_list (call_expression function: (identifier) arguments: (argument_list))))
+        condition: (condition_clause
+          value: (declaration
+            (type_qualifier)
+            type: (primitive_type)
+            declarator: (identifier)
+          value: (initializer_list (call_expression function: (identifier) arguments: (argument_list)))))
         consequence: (compound_statement))
       (if_statement
-        condition: (init_statement
-          initializer: (declaration (type_qualifier) type: (primitive_type) declarator: (init_declarator declarator: (identifier) value: (call_expression function: (identifier) arguments: (argument_list))))
-          condition: (binary_expression left: (identifier) right: (number_literal)))
+        condition: (condition_clause
+          initializer: (declaration
+            (type_qualifier)
+            type: (primitive_type)
+            declarator: (init_declarator
+              declarator: (identifier)
+              value: (call_expression function: (identifier) arguments: (argument_list))))
+          value: (binary_expression left: (identifier) right: (number_literal)))
         consequence: (compound_statement)))))
 
 ===========================================

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -80,6 +80,12 @@ T f() {
     return t;
 }
 
+void f() {
+  if (const int x = foo()) { }
+  if (const int x { foo() }) { }
+  if (const int x = foo(); x != 0) { }
+}
+
 ---
 
 (translation_unit
@@ -99,7 +105,28 @@ T f() {
             (type_descriptor type: (type_identifier)))))
         consequence: (return_statement
           (pointer_expression argument: (identifier)))
-        alternative: (return_statement (identifier))))))
+        alternative: (return_statement (identifier)))))
+  (function_definition
+    type: (primitive_type)
+    declarator: (function_declarator
+      declarator: (identifier)
+      parameters: (parameter_list))
+    body: (compound_statement
+      (if_statement
+        condition: (condition_declaration
+          (type_qualifier) type: (primitive_type)
+          declarator: (identifier) default_value: (call_expression function: (identifier) arguments: (argument_list)))
+        consequence: (compound_statement))
+      (if_statement
+        condition: (condition_declaration
+          (type_qualifier) type: (primitive_type)
+          declarator: (identifier) (initializer_list (call_expression function: (identifier) arguments: (argument_list))))
+        consequence: (compound_statement))
+      (if_statement
+        condition: (init_statement
+          initializer: (declaration (type_qualifier) type: (primitive_type) declarator: (init_declarator declarator: (identifier) value: (call_expression function: (identifier) arguments: (argument_list))))
+          condition: (binary_expression left: (identifier) right: (number_literal)))
+        consequence: (compound_statement)))))
 
 ===========================================
 Try/catch statements


### PR DESCRIPTION
For reference:
https://en.cppreference.com/w/cpp/language/if
https://en.cppreference.com/w/cpp/language/while
https://en.cppreference.com/w/cpp/language/switch

And this patch handles C++17 init-statements too.