### PR TITLE
Various improvements to template parsing

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -443,6 +443,13 @@ int bar(T &t) { return u; }
 template <typename T>
 class Foo {};
 
+template <typename T>
+Foo<T>::Foo(int mem) : mem_(mem) {}
+
+template <typename T>
+template <typename U>
+void A<T>::foo(U&) {}
+
 ---
 
 (translation_unit
@@ -468,7 +475,93 @@ class Foo {};
   (template_declaration
     (template_parameter_list
       (type_parameter_declaration (type_identifier)))
-    (class_specifier (type_identifier) (field_declaration_list))))
+    (class_specifier (type_identifier) (field_declaration_list)))
+  (template_declaration
+    (template_parameter_list
+      (type_parameter_declaration (type_identifier)))
+    (function_definition
+      (function_declarator
+        (scoped_identifier
+          (template_type
+            (type_identifier)
+            (template_argument_list (type_descriptor (type_identifier))))
+          (identifier))
+        (parameter_list
+          (parameter_declaration (primitive_type) (identifier))))
+      (field_initializer_list
+        (field_initializer
+          (field_identifier)
+          (argument_list (identifier))))
+      (compound_statement)))
+  (template_declaration
+    (template_parameter_list
+      (type_parameter_declaration (type_identifier)))
+    (template_declaration
+      (template_parameter_list
+        (type_parameter_declaration (type_identifier)))
+      (function_definition
+        (primitive_type)
+        (function_declarator
+          (scoped_identifier
+            (template_type
+              (type_identifier)
+              (template_argument_list (type_descriptor (type_identifier))))
+            (identifier))
+          (parameter_list
+            (parameter_declaration
+              (type_identifier)
+              (abstract_reference_declarator))))
+        (compound_statement)))))
+
+=========================================
+Template template declarations
+=========================================
+
+template <template <typename> typename T>
+void foo() {}
+
+template <template <typename...> class>
+void bar() {}
+
+template <template <typename> typename...>
+void baz() {}
+
+---
+
+(translation_unit
+  (template_declaration
+    (template_parameter_list
+      (template_template_parameter_declaration
+        (template_parameter_list (type_parameter_declaration))
+        (type_parameter_declaration (type_identifier))))
+    (function_definition
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list))
+      (compound_statement)))
+  (template_declaration
+    (template_parameter_list
+      (template_template_parameter_declaration
+        (template_parameter_list (variadic_type_parameter_declaration))
+        (type_parameter_declaration)))
+    (function_definition
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list))
+      (compound_statement)))
+  (template_declaration
+    (template_parameter_list
+      (template_template_parameter_declaration
+        (template_parameter_list (type_parameter_declaration))
+        (variadic_type_parameter_declaration)))
+    (function_definition
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list))
+      (compound_statement))))
 
 =========================================
 Template specializations
@@ -557,6 +650,11 @@ class X
 {
 };
 
+template <typename = void>
+class Y
+{
+};
+
 ---
 
 (translation_unit
@@ -570,6 +668,13 @@ class X
             name: (type_identifier))
           arguments: (template_argument_list
             (type_descriptor type: (primitive_type))))))
+    (class_specifier
+      name: (type_identifier)
+      body: (field_declaration_list)))
+  (template_declaration
+    parameters: (template_parameter_list
+      (optional_type_parameter_declaration
+        default_type: (primitive_type)))
     (class_specifier
       name: (type_identifier)
       body: (field_declaration_list))))
@@ -753,6 +858,9 @@ class TT {
   }
 
   void func2(Ts &&... args) {}
+
+  template <typename...>
+  void func3() {}
 };
 
 ---
@@ -781,7 +889,15 @@ class TT {
               (variadic_parameter_declaration
                 (type_identifier)
                 (reference_declarator (variadic_declarator (identifier))))))
-          (compound_statement))))))
+          (compound_statement))
+        (template_declaration
+          (template_parameter_list (variadic_type_parameter_declaration))
+          (function_definition
+            (primitive_type)
+            (function_declarator
+              (identifier)
+              (parameter_list))
+            (compound_statement)))))))
 
 ============================
 Enums

--- a/grammar.js
+++ b/grammar.js
@@ -174,7 +174,9 @@ module.exports = grammar(C, {
       choice(
         $.declaration,
         $._empty_declaration,
-        $.function_definition
+        $.function_definition,
+        alias($.constructor_or_destructor_definition, $.function_definition),
+        $.template_declaration
       )
     ),
 
@@ -192,7 +194,8 @@ module.exports = grammar(C, {
         $.optional_parameter_declaration,
         $.type_parameter_declaration,
         $.variadic_type_parameter_declaration,
-        $.optional_type_parameter_declaration
+        $.optional_type_parameter_declaration,
+        $.template_template_parameter_declaration
       )),
       alias(token(prec(1, '>')), '>')
     ),
@@ -204,20 +207,30 @@ module.exports = grammar(C, {
 
     type_parameter_declaration: $ => prec(1, seq(
       choice('typename', 'class'),
-      $._type_identifier
+      optional($._type_identifier)
     )),
 
     variadic_type_parameter_declaration: $ => prec(1, seq(
       choice('typename', 'class'),
       '...',
-      $._type_identifier
+      optional($._type_identifier)
     )),
 
     optional_type_parameter_declaration: $ => seq(
-      'typename',
-      field('name', $._type_identifier),
+      choice('typename', 'class'),
+      optional(field('name', $._type_identifier)),
       '=',
       field('default_type', $._type_specifier)
+    ),
+
+    template_template_parameter_declaration: $ => seq(
+      'template',
+      field('parameters', $.template_parameter_list),
+      choice(
+        $.type_parameter_declaration,
+        $.variadic_type_parameter_declaration,
+        $.optional_type_parameter_declaration
+      )
     ),
 
     parameter_list: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6225,6 +6225,19 @@
             {
               "type": "SYMBOL",
               "name": "function_definition"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "constructor_or_destructor_definition"
+              },
+              "named": true,
+              "value": "function_definition"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "template_declaration"
             }
           ]
         }
@@ -6298,6 +6311,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "optional_type_parameter_declaration"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "template_template_parameter_declaration"
                     }
                   ]
                 },
@@ -6332,6 +6349,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "optional_type_parameter_declaration"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "template_template_parameter_declaration"
                           }
                         ]
                       }
@@ -6383,8 +6404,16 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "_type_identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_type_identifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
@@ -6413,8 +6442,16 @@
             "value": "..."
           },
           {
-            "type": "SYMBOL",
-            "name": "_type_identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_type_identifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
@@ -6423,16 +6460,33 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "typename"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "typename"
+            },
+            {
+              "type": "STRING",
+              "value": "class"
+            }
+          ]
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_type_identifier"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "name",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_type_identifier"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -6445,6 +6499,40 @@
             "type": "SYMBOL",
             "name": "_type_specifier"
           }
+        }
+      ]
+    },
+    "template_template_parameter_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "SYMBOL",
+            "name": "template_parameter_list"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_parameter_declaration"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "variadic_type_parameter_declaration"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "optional_type_parameter_declaration"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2394,7 +2394,7 @@
       },
       "name": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "type_identifier",
@@ -3441,7 +3441,7 @@
     "named": true,
     "fields": {
       "parameters": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -3452,7 +3452,7 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
@@ -3465,6 +3465,10 @@
         },
         {
           "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "template_declaration",
           "named": true
         }
       ]
@@ -3592,6 +3596,44 @@
         },
         {
           "type": "parameter_declaration",
+          "named": true
+        },
+        {
+          "type": "template_template_parameter_declaration",
+          "named": true
+        },
+        {
+          "type": "type_parameter_declaration",
+          "named": true
+        },
+        {
+          "type": "variadic_type_parameter_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_template_parameter_declaration",
+    "named": true,
+    "fields": {
+      "parameters": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "template_parameter_list",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "optional_type_parameter_declaration",
           "named": true
         },
         {
@@ -3867,7 +3909,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "type_identifier",
@@ -4085,7 +4127,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "type_identifier",


### PR DESCRIPTION
This implements support for the following:
* Template constructors defined outside class definition (Fixes #50)
* Nested template function definitions outside class definition
* Template template parameters
* Name-specifiers are now (correctly) optional in template parameters