### PR TITLE
Support for parameter pack expansions and improvements to lambda expressions

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -865,7 +865,6 @@ Variadic templates
 template <class T>
 class TT {
   template <typename... Ts>
-
   void func1(Ts ... args) {
     func3(nullptr);
   }

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -159,6 +159,14 @@ auto f = [&](int x) -> bool {
   return true;
 };
 
+auto g = [x, y](int z) {
+  return false;
+};
+
+auto h = [] {
+  return false;
+};
+
 ---
 
 (translation_unit
@@ -171,7 +179,23 @@ auto f = [&](int x) -> bool {
         (abstract_function_declarator
           (parameter_list (parameter_declaration (primitive_type) (identifier)))
           (trailing_return_type (primitive_type)))
-        (compound_statement (return_statement (true)))))))
+        (compound_statement (return_statement (true))))))
+  (declaration
+    (auto)
+    (init_declarator
+      (identifier)
+      (lambda_expression
+        (lambda_capture_specifier (identifier) (identifier))
+        (abstract_function_declarator
+          (parameter_list (parameter_declaration (primitive_type) (identifier))))
+        (compound_statement (return_statement (false))))))
+  (declaration
+    (auto)
+    (init_declarator
+      (identifier)
+      (lambda_expression
+        (lambda_capture_specifier)
+        (compound_statement (return_statement (false)))))))
 
 ====================================================
 Nested template calls
@@ -315,3 +339,220 @@ int main() {
           (binary_expression (identifier) (identifier))
           (binary_expression (identifier) (identifier))))
       (compound_statement)))))
+
+====================================================
+Parameter pack expansions
+====================================================
+
+container<A,B,C...> t1;
+container<C...,A,B> t2;
+
+typedef Tuple<Pair<Args1, Args2>...> type;
+
+f(&args...); // expands to f(&E1, &E2, &E3)
+f(n, ++args...); // expands to f(n, ++E1, ++E2, ++E3);
+f(++args..., n); // expands to f(++E1, ++E2, ++E3, n);
+f(const_cast<const Args*>(&args)...); // f(const_cast<const E1*>(&X1), const_cast<const E2*>(&X2), const_cast<const E3*>(&X3))
+f(h(args...) + args...); // expands to f(h(E1,E2,E3) + E1, h(E1,E2,E3) + E2, h(E1,E2,E3) + E3)
+
+const int size = sizeof...(args) + 2;
+int res[size] = {1,args...,2};
+int dummy[sizeof...(Ts)] = { (std::cout << args, 0)... };
+
+auto lm = [&, args...] { return g(args...); };
+
+class X : public Mixins... {
+public:
+    X(const Mixins&... mixins) : Mixins(mixins)... { }
+};
+
+template <typename... Args>
+void wrap(Args&&... args) {
+    f(forward<Args>(args)...);
+}
+
+---
+
+(translation_unit
+  (declaration
+    type: (template_type
+      name: (type_identifier)
+      arguments: (template_argument_list
+        (type_descriptor
+          type: (type_identifier))
+        (type_descriptor
+          type: (type_identifier))
+        (parameter_pack_expansion
+          pattern: (type_descriptor
+            type: (type_identifier)))))
+    declarator: (identifier))
+  (declaration
+    type: (template_type
+      name: (type_identifier)
+      arguments: (template_argument_list
+        (parameter_pack_expansion
+          pattern: (type_descriptor
+            type: (type_identifier)))
+        (type_descriptor
+          type: (type_identifier))
+        (type_descriptor
+          type: (type_identifier))))
+    declarator: (identifier))
+  (type_definition
+    type: (template_type
+      name: (type_identifier)
+      arguments: (template_argument_list
+        (parameter_pack_expansion
+          pattern: (type_descriptor
+            type: (template_type
+              name: (type_identifier)
+              arguments: (template_argument_list
+                (type_descriptor
+                  type: (type_identifier))
+                (type_descriptor
+                  type: (type_identifier))))))))
+    declarator: (type_identifier))
+  (expression_statement
+    (call_expression
+      function: (identifier)
+      arguments: (argument_list
+        (parameter_pack_expansion
+          pattern: (pointer_expression
+            argument: (identifier))))))
+  (comment)
+  (expression_statement
+    (call_expression
+      function: (identifier)
+      arguments: (argument_list
+        (identifier)
+        (parameter_pack_expansion
+          pattern: (update_expression
+            argument: (identifier))))))
+  (comment)
+  (expression_statement
+    (call_expression
+      function: (identifier)
+      arguments: (argument_list
+        (parameter_pack_expansion
+          pattern: (update_expression
+            argument: (identifier)))
+        (identifier))))
+  (comment)
+  (expression_statement
+    (call_expression
+      function: (identifier)
+      arguments: (argument_list
+        (parameter_pack_expansion
+          pattern: (call_expression
+            function: (template_function
+              name: (identifier)
+              arguments: (template_argument_list
+                (type_descriptor
+                  (type_qualifier)
+                  type: (type_identifier)
+                  declarator: (abstract_pointer_declarator))))
+            arguments: (argument_list
+              (pointer_expression argument: (identifier))))))))
+  (comment)
+  (expression_statement
+    (call_expression
+      function: (identifier)
+      arguments: (argument_list
+        (parameter_pack_expansion
+          pattern: (binary_expression
+            left: (call_expression
+              function: (identifier)
+              arguments: (argument_list
+                (parameter_pack_expansion pattern: (identifier))))
+            right: (identifier))))))
+  (comment)
+  (declaration
+    (type_qualifier)
+    type: (primitive_type)
+    declarator: (init_declarator
+      declarator: (identifier)
+      value: (binary_expression
+          left: (sizeof_expression value: (identifier))
+          right: (number_literal))))
+  (declaration
+    type: (primitive_type)
+    declarator: (init_declarator
+      declarator: (array_declarator
+        declarator: (identifier)
+        size: (identifier))
+      value: (initializer_list
+        (number_literal)
+        (parameter_pack_expansion pattern: (identifier))
+        (number_literal))))
+  (declaration
+    type: (primitive_type)
+    declarator: (init_declarator
+      declarator: (array_declarator
+        declarator: (identifier)
+        size: (sizeof_expression value: (identifier)))
+      value: (initializer_list
+        (parameter_pack_expansion
+          pattern: (parenthesized_expression
+            (comma_expression
+              left: (binary_expression
+                left: (scoped_identifier
+                  namespace: (namespace_identifier)
+                  name: (identifier))
+                right: (identifier))
+              right: (number_literal)))))))
+  (declaration
+    type: (auto)
+    declarator: (init_declarator
+      declarator: (identifier)
+      value: (lambda_expression
+        captures: (lambda_capture_specifier
+          (lambda_default_capture)
+          (parameter_pack_expansion pattern: (identifier)))
+        body: (compound_statement
+          (return_statement
+            (call_expression
+              function: (identifier)
+              arguments: (argument_list
+                (parameter_pack_expansion pattern: (identifier)))))))))
+  (class_specifier
+    name: (type_identifier)
+    (base_class_clause
+      (type_identifier))
+    body: (field_declaration_list
+      (access_specifier)
+      (function_definition
+        declarator: (function_declarator
+          declarator: (identifier)
+          parameters: (parameter_list
+            (variadic_parameter_declaration
+              (type_qualifier)
+              type: (type_identifier)
+              declarator: (reference_declarator
+                (variadic_declarator (identifier))))))
+        (field_initializer_list
+          (field_initializer
+            (field_identifier)
+            (argument_list (identifier))))
+        body: (compound_statement))))
+  (template_declaration
+    parameters: (template_parameter_list (variadic_type_parameter_declaration (type_identifier)))
+    (function_definition
+      type: (primitive_type)
+      declarator: (function_declarator
+        declarator: (identifier)
+        parameters: (parameter_list
+          (variadic_parameter_declaration
+            type: (type_identifier)
+            declarator: (reference_declarator (variadic_declarator (identifier))))))
+      body: (compound_statement
+        (expression_statement
+          (call_expression
+            function: (identifier)
+            arguments: (argument_list
+              (parameter_pack_expansion
+                pattern: (call_expression
+                  function: (template_function
+                    name: (identifier)
+                    arguments: (template_argument_list
+                      (type_descriptor type: (type_identifier))))
+                  arguments: (argument_list (identifier)))))))))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3780,6 +3780,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "parameter_pack_expansion"
+        },
+        {
+          "type": "SYMBOL",
           "name": "nullptr"
         },
         {
@@ -4783,51 +4787,85 @@
       ]
     },
     "sizeof_expression": {
-      "type": "PREC",
-      "value": 8,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "sizeof"
-          },
-          {
-            "type": "CHOICE",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 8,
+          "content": {
+            "type": "SEQ",
             "members": [
               {
-                "type": "FIELD",
-                "name": "value",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
+                "type": "STRING",
+                "value": "sizeof"
               },
               {
-                "type": "SEQ",
+                "type": "CHOICE",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  {
                     "type": "FIELD",
-                    "name": "type",
+                    "name": "value",
                     "content": {
                       "type": "SYMBOL",
-                      "name": "type_descriptor"
+                      "name": "_expression"
                     }
                   },
                   {
-                    "type": "STRING",
-                    "value": ")"
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "("
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "type",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "type_descriptor"
+                        }
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ")"
+                      }
+                    ]
                   }
                 ]
               }
             ]
           }
-        ]
-      }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "sizeof"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "FIELD",
+              "name": "value",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
     },
     "subscript_expression": {
       "type": "PREC",
@@ -6122,6 +6160,18 @@
                 {
                   "type": "SYMBOL",
                   "name": "_class_name"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "..."
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
@@ -6165,6 +6215,18 @@
                       {
                         "type": "SYMBOL",
                         "name": "_class_name"
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "..."
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -6706,6 +6768,18 @@
               {
                 "type": "SYMBOL",
                 "name": "argument_list"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "..."
+              },
+              {
+                "type": "BLANK"
               }
             ]
           }
@@ -7350,10 +7424,23 @@
                   "members": [
                     {
                       "type": "PREC_DYNAMIC",
-                      "value": 2,
+                      "value": 3,
                       "content": {
                         "type": "SYMBOL",
                         "name": "type_descriptor"
+                      }
+                    },
+                    {
+                      "type": "PREC_DYNAMIC",
+                      "value": 2,
+                      "content": {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "type_parameter_pack_expansion"
+                        },
+                        "named": true,
+                        "value": "parameter_pack_expansion"
                       }
                     },
                     {
@@ -7380,10 +7467,23 @@
                         "members": [
                           {
                             "type": "PREC_DYNAMIC",
-                            "value": 2,
+                            "value": 3,
                             "content": {
                               "type": "SYMBOL",
                               "name": "type_descriptor"
+                            }
+                          },
+                          {
+                            "type": "PREC_DYNAMIC",
+                            "value": 2,
+                            "content": {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "type_parameter_pack_expansion"
+                              },
+                              "named": true,
+                              "value": "parameter_pack_expansion"
                             }
                           },
                           {
@@ -7871,12 +7971,20 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "declarator",
-          "content": {
-            "type": "SYMBOL",
-            "name": "abstract_function_declarator"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "declarator",
+              "content": {
+                "type": "SYMBOL",
+                "name": "abstract_function_declarator"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -7937,6 +8045,44 @@
                     "type": "BLANK"
                   }
                 ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "lambda_default_capture"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expression"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "_expression"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -7957,6 +8103,44 @@
         {
           "type": "STRING",
           "value": "&"
+        }
+      ]
+    },
+    "parameter_pack_expansion": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "pattern",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "..."
+          }
+        ]
+      }
+    },
+    "type_parameter_pack_expansion": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "pattern",
+          "content": {
+            "type": "SYMBOL",
+            "name": "type_descriptor"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "..."
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -148,6 +148,10 @@
         "named": true
       },
       {
+        "type": "parameter_pack_expansion",
+        "named": true
+      },
+      {
         "type": "parenthesized_expression",
         "named": true
       },
@@ -2158,7 +2162,7 @@
       },
       "declarator": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "abstract_function_declarator",
@@ -2477,6 +2481,22 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "parameter_pack_expansion",
+    "named": true,
+    "fields": {
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_descriptor",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3262,6 +3282,10 @@
           {
             "type": "_expression",
             "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
           }
         ]
       }
@@ -3427,6 +3451,10 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "parameter_pack_expansion",
           "named": true
         },
         {


### PR DESCRIPTION
Fixes #27

For information about parameter packs, see
https://en.cppreference.com/w/cpp/language/parameter_pack

Most expansion loci should work with this commit since it is implemented
as an expression, so anywhere an expression is valid, parameter pack
expansions will be parsed.

This commit also adds support for:
* The sizeof... operator (as an alternative to sizeof)
* Lambda captures can optionally start with a default capture along with
  other captures
* Lambda function declarators (the parameter list) are optional

Tests added for the following parameter pack expansion loci:
* Function parameter and argument lists
* Template argument lists
* Base class specifiers and member initializer lists
* Lambda captures