### PR TITLE
Add (u|u8|U|L)R raw string literal support

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -19,8 +19,26 @@ struct Scanner {
 
     lexer->result_symbol = RAW_STRING_LITERAL;
 
+    // Raw string literals can start with: R, LR, uR, UR, u8R
     // Consume 'R'
-    if (lexer->lookahead != 'R') return false;
+    if (lexer->lookahead == 'L' || lexer->lookahead == 'U') {
+      lexer->advance(lexer, false);
+      if (lexer->lookahead != 'R') {
+        return false;
+      }
+    } else if (lexer->lookahead == 'u') {
+      lexer->advance(lexer, false);
+      if (lexer->lookahead == '8') {
+        lexer->advance(lexer, false);
+        if (lexer->lookahead != 'R') {
+          return false;
+        }
+      } else if (lexer->lookahead != 'R') {
+        return false;
+      }
+    } else if (lexer->lookahead != 'R') {
+      return false;
+    }
     lexer->advance(lexer, false);
 
     // Consume '"'

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -289,9 +289,49 @@ const char *s2 = R"FOO(
   This is a string. It ends with ')FOO' and a quote.
 )FOO";
 
+const char *s3 = uR"FOO(
+  This is a string. It ends with ')FOO' and a quote.
+)FOO";
+
+const char *s4 = UR"FOO(
+  This is a string. It ends with ')FOO' and a quote.
+)FOO";
+
+const char *s5 = u8R"FOO(
+  This is a string. It ends with ')FOO' and a quote.
+)FOO";
+
+const char *s6 = LR"FOO(
+  This is a string. It ends with ')FOO' and a quote.
+)FOO";
+
 ---
 
 (translation_unit
+  (declaration
+    (type_qualifier)
+    (primitive_type)
+    (init_declarator
+      (pointer_declarator (identifier))
+      (raw_string_literal)))
+  (declaration
+    (type_qualifier)
+    (primitive_type)
+    (init_declarator
+      (pointer_declarator (identifier))
+      (raw_string_literal)))
+  (declaration
+    (type_qualifier)
+    (primitive_type)
+    (init_declarator
+      (pointer_declarator (identifier))
+      (raw_string_literal)))
+  (declaration
+    (type_qualifier)
+    (primitive_type)
+    (init_declarator
+      (pointer_declarator (identifier))
+      (raw_string_literal)))
   (declaration
     (type_qualifier)
     (primitive_type)


### PR DESCRIPTION
Regenerate grammar on top of:
https://github.com/tree-sitter/tree-sitter-c/pull/36
And support all raw string types.
For reference:
https://en.cppreference.com/w/cpp/language/string_literal