### PR TITLE
Concatenated strings can contain raw string literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,4 +1,4 @@
-const C = require("tree-sitter-c/grammar")
+const C = require("../tree-sitter-c/grammar")
 
 const PREC = Object.assign(C.PREC, {
   LAMBDA: 18,
@@ -781,6 +781,11 @@ module.exports = grammar(C, {
 
     this: $ => 'this',
     nullptr: $ => 'nullptr',
+
+    concatenated_string: $ => seq(
+      choice($.raw_string_literal, $.string_literal),
+      repeat1(choice($.raw_string_literal, $.string_literal))
+    ),
 
     _namespace_identifier: $ => alias($.identifier, $.namespace_identifier),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1,4 +1,4 @@
-const C = require("../tree-sitter-c/grammar")
+const C = require("tree-sitter-c/grammar")
 
 const PREC = Object.assign(C.PREC, {
   LAMBDA: 18,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6649,14 +6649,32 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "string_literal"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "raw_string_literal"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string_literal"
+            }
+          ]
         },
         {
           "type": "REPEAT1",
           "content": {
-            "type": "SYMBOL",
-            "name": "string_literal"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "raw_string_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "string_literal"
+              }
+            ]
           }
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1337,6 +1337,10 @@
       "required": true,
       "types": [
         {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
           "type": "string_literal",
           "named": true
         }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -596,3 +596,17 @@ void wrap(Args&&... args) {
                     arguments: (template_argument_list
                       (type_descriptor type: (type_identifier))))
                   arguments: (argument_list (identifier)))))))))))
+
+============================================
+Concatenated string literals
+============================================
+
+"a" "b" "c";
+R"(a)" R"(b)" R"(c)";
+"a" R"(b)" L"c" R"FOO(d)FOO";
+---
+
+(translation_unit
+  (expression_statement (concatenated_string (string_literal) (string_literal) (string_literal)))
+  (expression_statement (concatenated_string (raw_string_literal) (raw_string_literal) (raw_string_literal)))
+  (expression_statement (concatenated_string (string_literal) (raw_string_literal) (string_literal) (raw_string_literal))))


### PR DESCRIPTION
No restriction in the standard and it exists in real life:
https://hg.mozilla.org/mozilla-central/file/tip/dom/indexedDB/ActorsParent.cpp#l16956