### PR TITLE
Fix explicit ctor declaration and support explicit with condition (c++20)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -73,7 +73,6 @@ module.exports = grammar(C, {
     type_qualifier: ($, original) => choice(
       original,
       'mutable',
-      'explicit',
       'constexpr'
     ),
 
@@ -132,6 +131,16 @@ module.exports = grammar(C, {
 
     virtual_function_specifier: $ => choice(
       'virtual'
+    ),
+
+    explicit_function_specifier: $ => choice(
+      'explicit',
+      prec(PREC.CALL, seq(
+        'explicit',
+        '(',
+        $._expression,
+        ')'
+      ))
     ),
 
     base_class_clause: $ => seq(
@@ -357,7 +366,7 @@ module.exports = grammar(C, {
         $.attribute_specifier
       )),
       prec(1, seq(
-        optional($.virtual_function_specifier),
+        optional(choice($.virtual_function_specifier, $.explicit_function_specifier)),
         field('declarator', $.function_declarator),
         optional($.field_initializer_list)
       )),
@@ -369,7 +378,7 @@ module.exports = grammar(C, {
     ),
 
     constructor_or_destructor_declaration: $ => seq(
-      optional($.virtual_function_specifier),
+      optional(choice($.virtual_function_specifier, $.explicit_function_specifier)),
       field('declarator', $.function_declarator),
       ';'
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2992,10 +2992,6 @@
         },
         {
           "type": "STRING",
-          "value": "explicit"
-        },
-        {
-          "type": "STRING",
           "value": "constexpr"
         }
       ]
@@ -7083,6 +7079,40 @@
         }
       ]
     },
+    "explicit_function_specifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "explicit"
+        },
+        {
+          "type": "PREC",
+          "value": 14,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "explicit"
+              },
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "base_class_clause": {
       "type": "SEQ",
       "members": [
@@ -7840,8 +7870,17 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "virtual_function_specifier"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "virtual_function_specifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "explicit_function_specifier"
+                      }
+                    ]
                   },
                   {
                     "type": "BLANK"
@@ -7901,8 +7940,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "virtual_function_specifier"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "virtual_function_specifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "explicit_function_specifier"
+                }
+              ]
             },
             {
               "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1442,6 +1442,10 @@
           "named": true
         },
         {
+          "type": "explicit_function_specifier",
+          "named": true
+        },
+        {
           "type": "storage_class_specifier",
           "named": true
         },
@@ -1723,6 +1727,21 @@
       "types": [
         {
           "type": "enumerator",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "explicit_function_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
           "named": true
         }
       ]
@@ -2253,6 +2272,10 @@
         },
         {
           "type": "delete_method_clause",
+          "named": true
+        },
+        {
+          "type": "explicit_function_specifier",
           "named": true
         },
         {

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -68,7 +68,7 @@ class C {
     (type_identifier)
     (field_declaration_list
       (function_definition
-        (type_qualifier)
+        (explicit_function_specifier)
         (function_declarator
           (identifier)
           (parameter_list (parameter_declaration (primitive_type) (identifier))))
@@ -77,6 +77,28 @@ class C {
         (compound_statement))
       (access_specifier)
         (field_declaration (primitive_type) (field_identifier)))))
+
+=====================================
+Explicit constructor declaration
+=====================================
+
+class C {
+  explicit C(int f);
+  explicit(true) C(long f);
+};
+
+---
+
+(translation_unit
+  (class_specifier
+    (type_identifier)
+    (field_declaration_list
+      (declaration
+        (explicit_function_specifier)
+        (function_declarator (identifier) (parameter_list (parameter_declaration (primitive_type) (identifier)))))
+      (declaration
+        (explicit_function_specifier (true))
+        (function_declarator (identifier) (parameter_list (parameter_declaration (sized_type_specifier) (identifier))))))))
 
 =====================================
 Default and deleted methods


### PR DESCRIPTION
```cpp
class DefaultArea final : public Area {
    explicit DefaultArea(HTMLAreaElement* aArea);
};
``` 
was leading to an error so fix it.
For reference:
https://en.cppreference.com/w/cpp/language/explicit