### PR TITLE
Improve parsing of friend declarations 

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -436,7 +436,14 @@ module.exports = grammar(C, {
       choice(
         $.declaration,
         $.function_definition,
-        seq($.class_specifier, ';')
+        seq(
+          optional(choice(
+            'class',
+            'struct',
+            'union'
+          )),
+          $._class_name, ';'
+        )
       )
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8347,8 +8347,33 @@
               "type": "SEQ",
               "members": [
                 {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "class"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "struct"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "union"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
                   "type": "SYMBOL",
-                  "name": "class_specifier"
+                  "name": "_class_name"
                 },
                 {
                   "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2151,15 +2151,23 @@
       "required": true,
       "types": [
         {
-          "type": "class_specifier",
-          "named": true
-        },
-        {
           "type": "declaration",
           "named": true
         },
         {
           "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "scoped_type_identifier",
+          "named": true
+        },
+        {
+          "type": "template_type",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
           "named": true
         }
       ]

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -327,6 +327,7 @@ Friend declarations
 
 struct C {
   friend class D;
+  friend D;
   friend int f(C &);
 };
 
@@ -334,7 +335,8 @@ struct C {
 
 (translation_unit
   (struct_specifier (type_identifier) (field_declaration_list
-    (friend_declaration (class_specifier (type_identifier)))
+    (friend_declaration (type_identifier))
+    (friend_declaration (type_identifier))
     (friend_declaration (declaration (primitive_type) (function_declarator
       (identifier)
       (parameter_list (parameter_declaration (type_identifier) (abstract_reference_declarator)))))))))


### PR DESCRIPTION
Improve parsing of friend declarations when using c++11 simple type specifier

Also resolves possible erroneous parsing of a friend declaration attempting to define a new class.