### PR TITLE
Fix array assignment expressions so they don't parse as structured bindings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -3,7 +3,7 @@ const C = require("tree-sitter-c/grammar")
 const PREC = Object.assign(C.PREC, {
   LAMBDA: 18,
   NEW: C.PREC.CALL + 1,
-  STRUCTURED_BINDING: C.PREC.ASSIGNMENT - 1,
+  STRUCTURED_BINDING: -1,
 })
 
 module.exports = grammar(C, {
@@ -41,7 +41,6 @@ module.exports = grammar(C, {
       $.static_assert_declaration,
       $.template_declaration,
       $.template_instantiation,
-      // $.structured_binding_declaration,
       alias($.constructor_or_destructor_definition, $.function_definition),
       alias($.operator_cast_definition, $.function_definition),
       alias($.operator_cast_declaration, $._declaration),
@@ -476,8 +475,9 @@ module.exports = grammar(C, {
     reference_field_declarator: $ => prec.dynamic(1, prec.right(seq(choice('&', '&&'), $._field_declarator))),
     abstract_reference_declarator: $ => prec.right(seq(choice('&', '&&'), optional($._abstract_declarator))),
 
-    // structured_binding_reference_declarator: $ => seq(choice('&', '&&'), $.structured_binding_declarator),
-    structured_binding_declarator: $ => prec.dynamic(PREC.STRUCTURED_BINDING, seq('[', commaSep1($.identifier), ']')),
+    structured_binding_declarator: $ => prec.dynamic(PREC.STRUCTURED_BINDING, seq(
+      '[', commaSep1($.identifier), ']'
+    )),
 
     function_declarator: ($, original) => seq(
       original,

--- a/grammar.js
+++ b/grammar.js
@@ -3,6 +3,7 @@ const C = require("tree-sitter-c/grammar")
 const PREC = Object.assign(C.PREC, {
   LAMBDA: 18,
   NEW: C.PREC.CALL + 1,
+  STRUCTURED_BINDING: C.PREC.ASSIGNMENT - 1,
 })
 
 module.exports = grammar(C, {
@@ -476,7 +477,7 @@ module.exports = grammar(C, {
     abstract_reference_declarator: $ => prec.right(seq(choice('&', '&&'), optional($._abstract_declarator))),
 
     // structured_binding_reference_declarator: $ => seq(choice('&', '&&'), $.structured_binding_declarator),
-    structured_binding_declarator: $ => seq('[', commaSep1($.identifier), ']'),
+    structured_binding_declarator: $ => prec.dynamic(PREC.STRUCTURED_BINDING, seq('[', commaSep1($.identifier), ']')),
 
     function_declarator: ($, original) => seq(
       original,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8482,7 +8482,7 @@
     },
     "structured_binding_declarator": {
       "type": "PREC_DYNAMIC",
-      "value": -2,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8481,42 +8481,46 @@
       }
     },
     "structured_binding_declarator": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                ]
+      "type": "PREC_DYNAMIC",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
               }
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "]"
-        }
-      ]
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
     },
     "trailing_return_type": {
       "type": "PREC_RIGHT",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -653,3 +653,20 @@ x = (int(1) + float(2));
         (binary_expression
           (call_expression (primitive_type) (argument_list (number_literal)))
           (call_expression (primitive_type) (argument_list (number_literal))))))))
+
+============================================
+Array assignment expression
+============================================
+
+array_[i] = s[i];
+
+---
+(translation_unit
+  (expression_statement
+    (assignment_expression
+      (subscript_expression
+        (identifier)
+        (identifier))
+      (subscript_expression
+        (identifier)
+        (identifier)))))


### PR DESCRIPTION
Array assignment expressions were broken in https://github.com/tree-sitter/tree-sitter-cpp/commit/df7bc44e3387d1ba9e77f3ac22a1acb1d30f90ab which added more
support for structured binding declarators. We need to add a dynamic
precedence that is lower than that of an assignment expression so that
code is parsed as an assignment expression before it's parsed as a
structured binding.

@maxbrunsfeld feel free to let me know a better way to assign the precedence, here. I know it needs to be lower than that of an assignment expression, but I'm not sure I picked the best way to do it.