### PR TITLE
Add support for Microsoft-specific modifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -26,6 +26,7 @@ module.exports = grammar(C, {
     [$._expression, $._declarator, $._type_specifier],
     [$.parameter_list, $.argument_list],
     [$._type_specifier, $.call_expression],
+    [$._declaration_specifiers, $.operator_cast_definition, $.constructor_or_destructor_definition],
   ]),
 
   inline: ($, original) => original.concat([
@@ -83,6 +84,7 @@ module.exports = grammar(C, {
     // with an associativity.
     class_specifier: $ => prec.right(seq(
       'class',
+      optional($.ms_declspec_modifier),
       choice(
         field('name', $._class_name),
         seq(
@@ -96,6 +98,7 @@ module.exports = grammar(C, {
 
     union_specifier: $ => prec.right(seq(
       'union',
+      optional($.ms_declspec_modifier),
       choice(
         field('name', $._class_name),
         seq(
@@ -109,6 +112,7 @@ module.exports = grammar(C, {
 
     struct_specifier: $ => prec.right(seq(
       'struct',
+      optional($.ms_declspec_modifier),
       choice(
         field('name', $._class_name),
         seq(

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.14.0"
   },
   "devDependencies": {
-    "tree-sitter-c": "^0.16.0",
+    "tree-sitter-c": "^0.16.1",
     "tree-sitter-cli": "^0.16.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-cpp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "C++ grammar for tree-sitter",
   "main": "index.js",
   "keywords": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1700,6 +1700,18 @@
           "type": "SEQ",
           "members": [
             {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ms_call_modifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
               "type": "SYMBOL",
               "name": "_declaration_specifiers"
             },
@@ -1879,6 +1891,10 @@
               {
                 "type": "SYMBOL",
                 "name": "attribute_specifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "ms_declspec_modifier"
               }
             ]
           }
@@ -1907,6 +1923,10 @@
               {
                 "type": "SYMBOL",
                 "name": "attribute_specifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "ms_declspec_modifier"
               }
             ]
           }
@@ -1969,6 +1989,115 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "ms_declspec_modifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__declspec"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "ms_based_modifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__based"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        }
+      ]
+    },
+    "ms_call_modifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__cdecl"
+        },
+        {
+          "type": "STRING",
+          "value": "__clrcall"
+        },
+        {
+          "type": "STRING",
+          "value": "__stdcall"
+        },
+        {
+          "type": "STRING",
+          "value": "__fastcall"
+        },
+        {
+          "type": "STRING",
+          "value": "__thiscall"
+        },
+        {
+          "type": "STRING",
+          "value": "__vectorcall"
+        }
+      ]
+    },
+    "ms_restrict_modifier": {
+      "type": "STRING",
+      "value": "__restrict"
+    },
+    "ms_unsigned_ptr_modifier": {
+      "type": "STRING",
+      "value": "__uptr"
+    },
+    "ms_signed_ptr_modifier": {
+      "type": "STRING",
+      "value": "__sptr"
+    },
+    "ms_unaligned_ptr_modifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "_unaligned"
+        },
+        {
+          "type": "STRING",
+          "value": "__unaligned"
+        }
+      ]
+    },
+    "ms_pointer_modifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "ms_unaligned_ptr_modifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ms_restrict_modifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ms_unsigned_ptr_modifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ms_signed_ptr_modifier"
         }
       ]
     },
@@ -2282,8 +2411,27 @@
           "type": "SEQ",
           "members": [
             {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ms_based_modifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
               "type": "STRING",
               "value": "*"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ms_pointer_modifier"
+              }
             },
             {
               "type": "REPEAT",
@@ -2314,8 +2462,27 @@
           "type": "SEQ",
           "members": [
             {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ms_based_modifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
               "type": "STRING",
               "value": "*"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ms_pointer_modifier"
+              }
             },
             {
               "type": "REPEAT",
@@ -2346,8 +2513,27 @@
           "type": "SEQ",
           "members": [
             {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ms_based_modifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
               "type": "STRING",
               "value": "*"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ms_pointer_modifier"
+              }
             },
             {
               "type": "REPEAT",
@@ -3394,6 +3580,18 @@
             "type": "CHOICE",
             "members": [
               {
+                "type": "SYMBOL",
+                "name": "ms_declspec_modifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
                 "type": "FIELD",
                 "name": "name",
                 "content": {
@@ -3468,6 +3666,18 @@
           {
             "type": "STRING",
             "value": "union"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "ms_declspec_modifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -7022,6 +7232,18 @@
             "type": "CHOICE",
             "members": [
               {
+                "type": "SYMBOL",
+                "name": "ms_declspec_modifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
                 "type": "FIELD",
                 "name": "name",
                 "content": {
@@ -10245,6 +10467,11 @@
     [
       "_type_specifier",
       "call_expression"
+    ],
+    [
+      "_declaration_specifiers",
+      "operator_cast_definition",
+      "constructor_or_destructor_definition"
     ]
   ],
   "externals": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1127,6 +1127,10 @@
           "named": true
         },
         {
+          "type": "ms_declspec_modifier",
+          "named": true
+        },
+        {
           "type": "virtual_specifier",
           "named": true
         }
@@ -1457,6 +1461,10 @@
         },
         {
           "type": "explicit_function_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
           "named": true
         },
         {
@@ -1840,6 +1848,10 @@
           "named": true
         },
         {
+          "type": "ms_declspec_modifier",
+          "named": true
+        },
+        {
           "type": "storage_class_specifier",
           "named": true
         },
@@ -2071,6 +2083,10 @@
       "types": [
         {
           "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
           "named": true
         },
         {
@@ -2306,6 +2322,14 @@
         },
         {
           "type": "field_initializer_list",
+          "named": true
+        },
+        {
+          "type": "ms_call_modifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
           "named": true
         },
         {
@@ -2587,6 +2611,73 @@
     }
   },
   {
+    "type": "ms_based_modifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ms_call_modifier",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ms_declspec_modifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ms_pointer_modifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "ms_restrict_modifier",
+          "named": true
+        },
+        {
+          "type": "ms_signed_ptr_modifier",
+          "named": true
+        },
+        {
+          "type": "ms_unaligned_ptr_modifier",
+          "named": true
+        },
+        {
+          "type": "ms_unsigned_ptr_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ms_unaligned_ptr_modifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "namespace_definition",
     "named": true,
     "fields": {
@@ -2755,6 +2846,10 @@
           "named": true
         },
         {
+          "type": "ms_declspec_modifier",
+          "named": true
+        },
+        {
           "type": "storage_class_specifier",
           "named": true
         },
@@ -2806,6 +2901,10 @@
       "types": [
         {
           "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
           "named": true
         },
         {
@@ -2884,6 +2983,10 @@
         },
         {
           "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
           "named": true
         },
         {
@@ -3013,6 +3116,14 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "ms_based_modifier",
+          "named": true
+        },
+        {
+          "type": "ms_pointer_modifier",
+          "named": true
+        },
         {
           "type": "type_qualifier",
           "named": true
@@ -4063,6 +4174,10 @@
           "named": true
         },
         {
+          "type": "ms_declspec_modifier",
+          "named": true
+        },
+        {
           "type": "virtual_specifier",
           "named": true
         }
@@ -4273,6 +4388,10 @@
       "types": [
         {
           "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
           "named": true
         },
         {
@@ -4761,6 +4880,10 @@
           "named": true
         },
         {
+          "type": "ms_declspec_modifier",
+          "named": true
+        },
+        {
           "type": "virtual_specifier",
           "named": true
         }
@@ -4866,6 +4989,10 @@
       "types": [
         {
           "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
           "named": true
         },
         {
@@ -5171,6 +5298,46 @@
     "named": false
   },
   {
+    "type": "__based",
+    "named": false
+  },
+  {
+    "type": "__cdecl",
+    "named": false
+  },
+  {
+    "type": "__clrcall",
+    "named": false
+  },
+  {
+    "type": "__declspec",
+    "named": false
+  },
+  {
+    "type": "__fastcall",
+    "named": false
+  },
+  {
+    "type": "__stdcall",
+    "named": false
+  },
+  {
+    "type": "__thiscall",
+    "named": false
+  },
+  {
+    "type": "__unaligned",
+    "named": false
+  },
+  {
+    "type": "__vectorcall",
+    "named": false
+  },
+  {
+    "type": "_unaligned",
+    "named": false
+  },
+  {
     "type": "auto",
     "named": true
   },
@@ -5281,6 +5448,18 @@
   {
     "type": "long",
     "named": false
+  },
+  {
+    "type": "ms_restrict_modifier",
+    "named": true
+  },
+  {
+    "type": "ms_signed_ptr_modifier",
+    "named": true
+  },
+  {
+    "type": "ms_unsigned_ptr_modifier",
+    "named": true
   },
   {
     "type": "mutable",

--- a/test/corpus/microsoft.txt
+++ b/test/corpus/microsoft.txt
@@ -1,0 +1,32 @@
+================================
+declaration specs
+================================
+
+struct __declspec(dllexport) s2
+{
+};
+
+union __declspec(noinline) u2 {
+};
+
+class __declspec(uuid) u2 {
+};
+
+---
+
+(translation_unit
+  (struct_specifier
+    (ms_declspec_modifier
+      (identifier))
+    name: (type_identifier)
+    body: (field_declaration_list))
+  (union_specifier
+    (ms_declspec_modifier
+      (identifier))
+    name: (type_identifier)
+    body: (field_declaration_list))
+  (class_specifier
+    (ms_declspec_modifier
+      (identifier))
+    name: (type_identifier)
+    body: (field_declaration_list)))


### PR DESCRIPTION
This PR updates tree-sitter-c to 0.16.1 to support Microsoft-specific modifiers as introduced in https://github.com/tree-sitter/tree-sitter-c/pull/40.

