### PR TITLE
Fixes for constructor declarations

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7186,7 +7186,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "[^*]*\\*+([^\\/*][^*]*\\*+)*"
+                "value": "[^*]*\\*+([^/*][^*]*\\*+)*"
               },
               {
                 "type": "STRING",
@@ -7601,10 +7601,28 @@
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
+                "name": "constructor_or_destructor_declaration"
+              },
+              "named": true,
+              "value": "declaration"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
                 "name": "constructor_or_destructor_definition"
               },
               "named": true,
               "value": "function_definition"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "operator_cast_declaration"
+              },
+              "named": true,
+              "value": "declaration"
             },
             {
               "type": "ALIAS",
@@ -8240,65 +8258,59 @@
         }
       ]
     },
+    "_constructor_specifiers": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "PREC_RIGHT",
+        "value": 0,
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "storage_class_specifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_qualifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "attribute_specifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "virtual_function_specifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "explicit_function_specifier"
+            }
+          ]
+        }
+      }
+    },
     "operator_cast_definition": {
       "type": "SEQ",
       "members": [
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "storage_class_specifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "type_qualifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "attribute_specifier"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_constructor_specifiers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
-          "type": "PREC",
-          "value": 1,
+          "type": "FIELD",
+          "name": "declarator",
           "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "virtual_function_specifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "explicit_function_specifier"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "FIELD",
-                "name": "declarator",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "operator_cast"
-                }
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "operator_cast"
           }
         },
         {
@@ -8325,23 +8337,72 @@
       ]
     },
     "operator_cast_declaration": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_constructor_specifiers"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "declarator",
+            "content": {
+              "type": "SYMBOL",
+              "name": "operator_cast"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "default_value",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ";"
+          }
+        ]
+      }
+    },
+    "constructor_or_destructor_definition": {
       "type": "SEQ",
       "members": [
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "virtual_function_specifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "explicit_function_specifier"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_constructor_specifiers"
             },
             {
               "type": "BLANK"
@@ -8353,112 +8414,20 @@
           "name": "declarator",
           "content": {
             "type": "SYMBOL",
-            "name": "operator_cast"
+            "name": "function_declarator"
           }
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "FIELD",
-                  "name": "default_value",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "field_initializer_list"
             },
             {
               "type": "BLANK"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": ";"
-        }
-      ]
-    },
-    "constructor_or_destructor_definition": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "storage_class_specifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "type_qualifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "attribute_specifier"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC",
-          "value": 1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "virtual_function_specifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "explicit_function_specifier"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "FIELD",
-                "name": "declarator",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "function_declarator"
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "field_initializer_list"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          }
         },
         {
           "type": "CHOICE",
@@ -8490,17 +8459,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "virtual_function_specifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "explicit_function_specifier"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_constructor_specifiers"
             },
             {
               "type": "BLANK"
@@ -10470,8 +10430,13 @@
     ],
     [
       "_declaration_specifiers",
+      "operator_cast_declaration",
       "operator_cast_definition",
       "constructor_or_destructor_definition"
+    ],
+    [
+      "_declaration_specifiers",
+      "_constructor_specifiers"
     ]
   ],
   "externals": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2413,7 +2413,7 @@
     "named": true,
     "fields": {
       "designator": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -232,6 +232,10 @@ class C {
  public:
   C();
   C(int, float);
+  inline C();
+  explicit inline C();
+  template <typename T>
+  C(T t);
   ~C();
 };
 
@@ -245,6 +249,10 @@ class C {
     (declaration (function_declarator (identifier) (parameter_list
       (parameter_declaration (primitive_type))
       (parameter_declaration (primitive_type)))))
+    (declaration (storage_class_specifier) (function_declarator (identifier) (parameter_list)))
+    (declaration (explicit_function_specifier) (storage_class_specifier) (function_declarator (identifier) (parameter_list)))
+    (template_declaration (template_parameter_list (type_parameter_declaration (type_identifier)))
+      (declaration (function_declarator (identifier) (parameter_list (parameter_declaration (type_identifier) (identifier))))))
     (declaration (function_declarator (destructor_name (identifier)) (parameter_list))))))
 
 =========================================
@@ -1009,7 +1017,8 @@ operator B&();
 operator auto() const;
 virtual operator A() = 0;
 A::B::operator C();
-
+template <typename T>
+operator T*();
 ---
 
 (translation_unit
@@ -1039,4 +1048,9 @@ A::B::operator C();
   (declaration
     (operator_cast
       (scoped_namespace_identifier (namespace_identifier) (namespace_identifier))
-      (type_identifier) (abstract_function_declarator (parameter_list)))))
+      (type_identifier) (abstract_function_declarator (parameter_list))))
+  (template_declaration
+    (template_parameter_list (type_parameter_declaration (type_identifier)))
+    (declaration (operator_cast
+      (type_identifier)
+      (abstract_pointer_declarator (abstract_function_declarator (parameter_list)))))))


### PR DESCRIPTION
Constructor declarations can have the same decl-specifiers as
constructor definitions. This adds a new rule to match as many
"constructor specifiers" that are present in any order before the
function decl itself, and adds the rule to constructor declarations and
constructor definitions.

The cast operator can also have any of these specifiers in any order
before the declaration, so this commit also changes the cast operator
declaration and definition to use the new rule as well.

Finally, constructor declarations and cast operator declarations can be
part of a template declaration in addition to the definitions, so add
them both to the template_declaration rule.