### PR TITLE
Highlight raw string literals

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -60,3 +60,7 @@
 "typename" @keyword
 "using" @keyword
 "virtual" @keyword
+
+; Strings
+
+(raw_string_literal) @string


### PR DESCRIPTION
As mentioned in issue #90, this one-liner should enable syntax highlighting for raw string literals