### PR TITLE
Support C++20 coroutines

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -632,6 +632,8 @@ module.exports = grammar(C, {
 
     _statement: ($, original) => choice(
       original,
+      $.co_return_statement,
+      $.co_yield_statement,
       $.for_range_loop,
       $.try_statement,
       $.throw_statement,
@@ -709,6 +711,18 @@ module.exports = grammar(C, {
       seq('return', $.initializer_list, ';')
     ),
 
+    co_return_statement: $ => seq(
+      'co_return',
+      optional($._expression),
+      ';'
+    ),
+
+    co_yield_statement: $ => seq(
+      'co_yield',
+      $._expression,
+      ';'
+    ),
+
     throw_statement: $ => seq(
       'throw',
       optional($._expression),
@@ -737,6 +751,7 @@ module.exports = grammar(C, {
 
     _expression: ($, original) => choice(
       original,
+      $.co_await_expression,
       $.template_function,
       $.scoped_identifier,
       $.new_expression,
@@ -751,6 +766,11 @@ module.exports = grammar(C, {
     call_expression: ($, original) => choice(original, seq(
       field('function', $.primitive_type),
       field('arguments', $.argument_list)
+    )),
+
+    co_await_expression: $ => prec.left(PREC.UNARY, seq(
+      field('operator', 'co_await'),
+      field('argument', $._expression)
     )),
 
     new_expression: $ => prec.right(PREC.NEW, seq(
@@ -911,6 +931,7 @@ module.exports = grammar(C, {
       'operator',
       /\s*/,
       choice(
+        'co_await',
         '+', '-', '*', '/', '%',
         '^', '&', '|', '~',
         '!', '=', '<', '>',

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -41,6 +41,9 @@
 
 "catch" @keyword
 "class" @keyword
+"co_await" @keyword
+"co_return" @keyword
+"co_yield" @keyword
 "constexpr" @keyword
 "delete" @keyword
 "explicit" @keyword

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4212,6 +4212,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "co_return_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "co_yield_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "for_range_loop"
         },
         {
@@ -4843,6 +4851,10 @@
               "name": "parenthesized_expression"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "co_await_expression"
         },
         {
           "type": "SYMBOL",
@@ -9496,6 +9508,48 @@
         }
       ]
     },
+    "co_return_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "co_return"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "co_yield_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "co_yield"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
     "throw_statement": {
       "type": "SEQ",
       "members": [
@@ -9607,6 +9661,31 @@
           "value": "]]"
         }
       ]
+    },
+    "co_await_expression": {
+      "type": "PREC_LEFT",
+      "value": 13,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "co_await"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "argument",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          }
+        ]
+      }
     },
     "new_expression": {
       "type": "PREC_RIGHT",
@@ -10225,6 +10304,10 @@
           {
             "type": "CHOICE",
             "members": [
+              {
+                "type": "STRING",
+                "value": "co_await"
+              },
               {
                 "type": "STRING",
                 "value": "+"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -100,6 +100,10 @@
         "named": true
       },
       {
+        "type": "co_await_expression",
+        "named": true
+      },
+      {
         "type": "compound_literal_expression",
         "named": true
       },
@@ -249,6 +253,14 @@
       },
       {
         "type": "case_statement",
+        "named": true
+      },
+      {
+        "type": "co_return_statement",
+        "named": true
+      },
+      {
+        "type": "co_yield_statement",
         "named": true
       },
       {
@@ -1092,6 +1104,62 @@
         },
         {
           "type": "virtual_specifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "co_await_expression",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "co_await",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "co_return_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "co_yield_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
           "named": true
         }
       ]
@@ -5310,6 +5378,18 @@
   },
   {
     "type": "class",
+    "named": false
+  },
+  {
+    "type": "co_await",
+    "named": false
+  },
+  {
+    "type": "co_return",
+    "named": false
+  },
+  {
+    "type": "co_yield",
     "named": false
   },
   {


### PR DESCRIPTION
C++20 introduces language support for coroutines, using three new
keywords and related language constructions.

* co_await is a unary operator.
* co_return introduces a statement, and works just like return or throw.
* co_yield similarly introduces a statement, but cannot stand for
  itself.

Add support for these facilities to the parser and highlighter.