### PR TITLE
Add coroutine tests

### DIFF
--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -670,3 +670,21 @@ array_[i] = s[i];
       (subscript_expression
         (identifier)
         (identifier)))))
+
+============================================
+Coroutines
+============================================
+
+co_await fn() || co_await var;
+
+---
+
+(translation_unit
+  (expression_statement
+    (binary_expression
+      (co_await_expression
+        (call_expression
+          (identifier)
+            (argument_list)))
+      (co_await_expression
+        (identifier)))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -322,3 +322,20 @@ void f() {
       (expression_statement (attribute (identifier)))
       (labeled_statement (attribute (identifier)) (statement_identifier) (compound_statement))
       (goto_statement (attribute (identifier)) (statement_identifier)))))
+
+===========================================
+Coroutines
+===========================================
+
+co_return 1;
+co_return;
+co_yield 1;
+
+---
+
+(translation_unit
+  (co_return_statement
+    (number_literal))
+  (co_return_statement)
+  (co_yield_statement
+    (number_literal)))


### PR DESCRIPTION
Test cases for correct parsing of co_return and co_yield statements as
well as co_await expressions are added to the corpus.