### PR TITLE
Ref-qualifiers on functions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -477,10 +477,13 @@ module.exports = grammar(C, {
       '[', commaSep1($.identifier), ']'
     )),
 
+    ref_qualifier: $ => choice('&', '&&'),
+
     function_declarator: ($, original) => prec.dynamic(1, seq(
       original,
       repeat(choice(
         $.type_qualifier,
+        $.ref_qualifier,
         $.virtual_specifier,
         $.noexcept,
         $.throw_specifier,
@@ -492,6 +495,7 @@ module.exports = grammar(C, {
       original,
       repeat(choice(
         $.type_qualifier,
+        $.ref_qualifier,
         $.virtual_specifier,
         $.noexcept,
         $.throw_specifier,
@@ -503,6 +507,7 @@ module.exports = grammar(C, {
       original,
       repeat(choice(
         $.type_qualifier,
+        $.ref_qualifier,
         $.noexcept,
         $.throw_specifier
       )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2801,6 +2801,10 @@
                 },
                 {
                   "type": "SYMBOL",
+                  "name": "ref_qualifier"
+                },
+                {
+                  "type": "SYMBOL",
                   "name": "virtual_specifier"
                 },
                 {
@@ -2860,6 +2864,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "type_qualifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "ref_qualifier"
                 },
                 {
                   "type": "SYMBOL",
@@ -2955,6 +2963,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "type_qualifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "ref_qualifier"
                 },
                 {
                   "type": "SYMBOL",
@@ -8934,6 +8946,19 @@
           }
         ]
       }
+    },
+    "ref_qualifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "STRING",
+          "value": "&&"
+        }
+      ]
     },
     "trailing_return_type": {
       "type": "PREC_RIGHT",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -487,6 +487,10 @@
           "named": true
         },
         {
+          "type": "ref_qualifier",
+          "named": true
+        },
+        {
           "type": "throw_specifier",
           "named": true
         },
@@ -2445,6 +2449,10 @@
           "named": true
         },
         {
+          "type": "ref_qualifier",
+          "named": true
+        },
+        {
           "type": "throw_specifier",
           "named": true
         },
@@ -4074,6 +4082,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "ref_qualifier",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "reference_declarator",

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1149,3 +1149,91 @@ thread_local int c;
   (declaration (storage_class_specifier) (primitive_type) (identifier))
   (declaration (storage_class_specifier) (primitive_type) (identifier))
   (declaration (storage_class_specifier) (primitive_type) (identifier)))
+
+=========================
+Ref-qualifiers
+=========================
+
+class C
+{
+  void f() &;
+  void f() && noexcept;
+  void f() & {}
+  void f() & noexcept {}
+};
+
+void C::f() &;
+void C::f() & noexcept;
+void C::f() && {}
+void C::f() & noexcept {}
+
+---
+
+(translation_unit
+  (class_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (primitive_type)
+        (function_declarator
+          (field_identifier)
+          (parameter_list)
+          (ref_qualifier)))
+      (field_declaration
+        (primitive_type)
+        (function_declarator
+          (field_identifier)
+          (parameter_list)
+          (ref_qualifier)
+          (noexcept)))
+      (function_definition
+        (primitive_type)
+        (function_declarator
+          (field_identifier)
+          (parameter_list)
+          (ref_qualifier))
+        (compound_statement))
+      (function_definition
+        (primitive_type)
+        (function_declarator
+          (field_identifier)
+          (parameter_list)
+          (ref_qualifier)
+          (noexcept))
+        (compound_statement))))
+  (declaration
+    (primitive_type)
+    (function_declarator
+      (scoped_identifier
+        (namespace_identifier)
+        (identifier))
+      (parameter_list)
+      (ref_qualifier)))
+  (declaration
+    (primitive_type)
+    (function_declarator
+      (scoped_identifier
+        (namespace_identifier)
+        (identifier))
+      (parameter_list)
+      (ref_qualifier)
+      (noexcept)))
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (scoped_identifier
+        (namespace_identifier)
+        (identifier))
+      (parameter_list)
+      (ref_qualifier))
+    (compound_statement))
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (scoped_identifier
+        (namespace_identifier)
+        (identifier))
+      (parameter_list)
+      (ref_qualifier)
+      (noexcept))
+    (compound_statement)))


### PR DESCRIPTION
Add support for the C++11 ref-qualifier syntax to the grammar. Add tests
that ref-qualifiers are parsed properly on both declarations and
definitions.

See http://eel.is/c++draft/dcl.fct and http://eel.is/c++draft/dcl.decl.general#nt:ref-qualifier .

https://en.cppreference.com/w/cpp/language/member_functions#ref-qualified_member_functions

Fixes #111 