### PR TITLE
Overhaul scoped identifier rules and add dependent name support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -16,10 +16,11 @@ module.exports = grammar(C, {
   conflicts: ($, original) => original.concat([
     [$.template_function, $.template_type],
     [$.template_function, $.template_type, $._expression],
-    [$.template_function, $._expression],
-    [$.template_method, $.template_type, $.field_expression],
-    [$.scoped_type_identifier, $.scoped_identifier],
-    [$.scoped_type_identifier, $.scoped_field_identifier],
+    [$.template_function, $.template_type, $.qualified_identifier],
+    [$.template_method, $.field_expression],
+    [$.template_type, $.qualified_type_identifier],
+    [$.qualified_type_identifier, $.qualified_identifier],
+    [$.dependent_type_identifier, $.dependent_identifier],
     [$.comma_expression, $.initializer_list],
     [$._expression, $._declarator],
     [$._expression, $.structured_binding_declarator],
@@ -71,7 +72,7 @@ module.exports = grammar(C, {
       $.dependent_type,
       $.decltype,
       prec.right(choice(
-        $.scoped_type_identifier,
+        alias($.qualified_type_identifier, $.qualified_identifier),
         $._type_identifier
       ))
     ),
@@ -129,8 +130,8 @@ module.exports = grammar(C, {
 
     _class_name: $ => prec.right(choice(
       $._type_identifier,
-      $.scoped_type_identifier,
-      $.template_type
+      $.template_type,
+      alias($.qualified_type_identifier, $.qualified_identifier)
     )),
 
     virtual_specifier: $ => choice(
@@ -181,7 +182,11 @@ module.exports = grammar(C, {
 
     _enum_base_clause: $ => prec.left(seq(
       ':',
-      field('base', choice($.scoped_type_identifier, $._type_identifier, $.sized_type_specifier))
+      field('base', choice(
+        alias($.qualified_type_identifier, $.qualified_identifier),
+        $._type_identifier,
+        $.sized_type_specifier
+      ))
     )),
 
     // The `auto` storage class is removed in C++0x in order to allow for the `auto` type.
@@ -311,15 +316,7 @@ module.exports = grammar(C, {
       )
     ),
 
-    operator_cast: $ => prec(1, seq(
-      optional(seq(
-        field('namespace', optional(choice(
-          $._namespace_identifier,
-          $.template_type,
-          $.scoped_namespace_identifier
-        ))),
-        '::',
-      )),
+    operator_cast: $ => prec.right(1, seq(
       'operator',
       $._declaration_specifiers,
       field('declarator', $._abstract_declarator),
@@ -335,7 +332,11 @@ module.exports = grammar(C, {
     ),
 
     field_initializer: $ => prec(1, seq(
-      choice($._field_identifier, $.scoped_field_identifier, $.template_method),
+      choice(
+        $._field_identifier,
+        $.template_method,
+        alias($.qualified_field_identifier, $.qualified_identifier),
+      ),
       choice($.initializer_list, $.argument_list),
       optional('...')
     )),
@@ -384,17 +385,19 @@ module.exports = grammar(C, {
 
     operator_cast_definition: $ => seq(
       repeat($._constructor_specifiers),
-      field('declarator', $.operator_cast),
-      choice(
-        field('body', $.compound_statement),
-        $.default_method_clause,
-        $.delete_method_clause
-      )
+      field('declarator', choice(
+        $.operator_cast,
+        alias($.qualified_operator_cast_identifier, $.qualified_identifier)
+      )),
+      field('body', $.compound_statement)
     ),
 
     operator_cast_declaration: $ => prec(1, seq(
       repeat($._constructor_specifiers),
-      field('declarator', $.operator_cast),
+      field('declarator', choice(
+        $.operator_cast,
+        alias($.qualified_operator_cast_identifier, $.qualified_identifier)
+      )),
       optional(seq('=', field('default_value', $._expression))),
       ';'
     )),
@@ -447,7 +450,7 @@ module.exports = grammar(C, {
     _declarator: ($, original) => choice(
       original,
       $.reference_declarator,
-      $.scoped_identifier,
+      $.qualified_identifier,
       $.template_function,
       $.operator_name,
       $.destructor_name,
@@ -539,17 +542,17 @@ module.exports = grammar(C, {
     ),
 
     template_type: $ => seq(
-      field('name', choice($._type_identifier, $.scoped_type_identifier)),
+      field('name', $._type_identifier),
       field('arguments', $.template_argument_list)
     ),
 
     template_method: $ => seq(
-      field('name', choice($._field_identifier, $.scoped_field_identifier)),
+      field('name', $._field_identifier),
       field('arguments', $.template_argument_list)
     ),
 
     template_function: $ => seq(
-      field('name', choice($.identifier, $.scoped_identifier)),
+      field('name', $.identifier),
       field('arguments', $.template_argument_list)
     ),
 
@@ -588,7 +591,7 @@ module.exports = grammar(C, {
       optional('namespace'),
       choice(
         $.identifier,
-        $.scoped_identifier
+        $.qualified_identifier
       ),
       ';'
     ),
@@ -738,7 +741,7 @@ module.exports = grammar(C, {
       original,
       $.co_await_expression,
       $.template_function,
-      $.scoped_identifier,
+      $.qualified_identifier,
       $.new_expression,
       $.delete_expression,
       $.lambda_expression,
@@ -802,7 +805,8 @@ module.exports = grammar(C, {
         )),
         field('field', choice(
           $.destructor_name,
-          $.template_method
+          $.template_method,
+          alias($.dependent_field_identifier, $.dependent_name)
         ))
       )
     ),
@@ -859,66 +863,67 @@ module.exports = grammar(C, {
     compound_literal_expression: ($, original) => choice(
       original,
       seq(
-        field('type', choice(
-          $._type_identifier,
-          $.template_type,
-          $.scoped_type_identifier
-        )),
+        field('type', $._class_name),
         field('value', $.initializer_list)
       )
     ),
 
-    scoped_field_identifier: $ => prec(1, seq(
-      field('namespace', optional(choice(
+    dependent_identifier: $ => seq('template', $.template_function),
+    dependent_field_identifier: $ => seq('template', $.template_method),
+    dependent_type_identifier: $ => seq('template', $.template_type),
+
+    _scope_resolution: $=> prec(1, seq(
+      field('scope', optional(choice(
         $._namespace_identifier,
         $.template_type,
-        $.scoped_namespace_identifier
+        alias($.dependent_type_identifier, $.dependent_name)
       ))),
       '::',
-      field('name', choice(
-        $._field_identifier,
-        $.operator_name,
-        $.destructor_name
-      ))
     )),
 
-    scoped_identifier: $ => prec(1, seq(
-      field('namespace', optional(choice(
-        $._namespace_identifier,
-        $.template_type,
-        $.scoped_namespace_identifier
-      ))),
-      '::',
+    qualified_field_identifier: $ => seq(
+      $._scope_resolution,
       field('name', choice(
+        alias($.dependent_field_identifier, $.dependent_name),
+        alias($.qualified_field_identifier, $.qualified_identifier),
+        $.template_method,
+        $._field_identifier
+      ))
+    ),
+
+    qualified_identifier: $ => seq(
+      $._scope_resolution,
+      field('name', choice(
+        alias($.dependent_identifier, $.dependent_name),
+        $.qualified_identifier,
+        $.template_function,
         $.identifier,
         $.operator_name,
         $.destructor_name
+      )),
+    ),
+
+    qualified_type_identifier: $ => seq(
+      $._scope_resolution,
+      field('name', choice(
+        alias($.dependent_type_identifier, $.dependent_name),
+        alias($.qualified_type_identifier, $.qualified_identifier),
+        $.template_type,
+        $._type_identifier
+      )),
+    ),
+
+    qualified_operator_cast_identifier: $ => seq(
+      $._scope_resolution,
+      field('name', choice(
+        alias($.qualified_operator_cast_identifier, $.qualified_identifier),
+        $.operator_cast
       ))
-    )),
-
-    scoped_type_identifier: $ => prec(1, seq(
-      field('namespace', optional(choice(
-        $._namespace_identifier,
-        $.template_type,
-        $.scoped_namespace_identifier
-      ))),
-      '::',
-      field('name', $._type_identifier)
-    )),
-
-    scoped_namespace_identifier: $ => prec(2, seq(
-      field('namespace', optional(choice(
-        $._namespace_identifier,
-        $.template_type,
-        $.scoped_namespace_identifier
-      ))),
-      '::',
-      field('name', $._namespace_identifier)
-    )),
+    ),
 
     _assignment_left_expression: ($, original) => choice(
       original,
-      $.scoped_namespace_identifier,
+      $.qualified_identifier,
     ),
 
     operator_name: $ => prec(1, seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,7 +1,7 @@
 ; Functions
 
 (call_expression
-  function: (scoped_identifier
+  function: (qualified_identifier
     name: (identifier) @function))
 
 (template_function
@@ -11,15 +11,14 @@
   name: (field_identifier) @function)
 
 (template_function
-  name: (scoped_identifier
+  name: (identifier) @function)
+
+(function_declarator
+  declarator: (qualified_identifier
     name: (identifier) @function))
 
 (function_declarator
-  declarator: (scoped_identifier
-    name: (identifier) @function))
-
-(function_declarator
-  declarator: (scoped_identifier
+  declarator: (qualified_identifier
     name: (identifier) @function))
 
 (function_declarator

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2227,7 +2227,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "scoped_identifier"
+          "name": "qualified_identifier"
         },
         {
           "type": "SYMBOL",
@@ -3424,8 +3424,13 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "scoped_type_identifier"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "qualified_type_identifier"
+                },
+                "named": true,
+                "value": "qualified_identifier"
               },
               {
                 "type": "SYMBOL",
@@ -5052,7 +5057,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "scoped_identifier"
+          "name": "qualified_identifier"
         },
         {
           "type": "SYMBOL",
@@ -5197,7 +5202,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "scoped_namespace_identifier"
+          "name": "qualified_identifier"
         }
       ]
     },
@@ -6433,6 +6438,15 @@
                   {
                     "type": "SYMBOL",
                     "name": "template_method"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "dependent_field_identifier"
+                    },
+                    "named": true,
+                    "value": "dependent_name"
                   }
                 ]
               }
@@ -6480,21 +6494,8 @@
               "type": "FIELD",
               "name": "type",
               "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_type_identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "template_type"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "scoped_type_identifier"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "_class_name"
               }
             },
             {
@@ -7552,11 +7553,16 @@
           },
           {
             "type": "SYMBOL",
-            "name": "scoped_type_identifier"
+            "name": "template_type"
           },
           {
-            "type": "SYMBOL",
-            "name": "template_type"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "qualified_type_identifier"
+            },
+            "named": true,
+            "value": "qualified_identifier"
           }
         ]
       }
@@ -7752,8 +7758,13 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "scoped_type_identifier"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "qualified_type_identifier"
+                  },
+                  "named": true,
+                  "value": "qualified_identifier"
                 },
                 {
                   "type": "SYMBOL",
@@ -8281,57 +8292,11 @@
       ]
     },
     "operator_cast": {
-      "type": "PREC",
+      "type": "PREC_RIGHT",
       "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "namespace",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "_namespace_identifier"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "template_type"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "scoped_namespace_identifier"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "::"
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
           {
             "type": "STRING",
             "value": "operator"
@@ -8400,11 +8365,16 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "scoped_field_identifier"
+                "name": "template_method"
               },
               {
-                "type": "SYMBOL",
-                "name": "template_method"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "qualified_field_identifier"
+                },
+                "named": true,
+                "value": "qualified_identifier"
               }
             ]
           },
@@ -8501,30 +8471,31 @@
           "type": "FIELD",
           "name": "declarator",
           "content": {
-            "type": "SYMBOL",
-            "name": "operator_cast"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "operator_cast"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "qualified_operator_cast_identifier"
+                },
+                "named": true,
+                "value": "qualified_identifier"
+              }
+            ]
           }
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "body",
-              "content": {
-                "type": "SYMBOL",
-                "name": "compound_statement"
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "default_method_clause"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "delete_method_clause"
-            }
-          ]
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "compound_statement"
+          }
         }
       ]
     },
@@ -8545,8 +8516,22 @@
             "type": "FIELD",
             "name": "declarator",
             "content": {
-              "type": "SYMBOL",
-              "name": "operator_cast"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "operator_cast"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "qualified_operator_cast_identifier"
+                  },
+                  "named": true,
+                  "value": "qualified_identifier"
+                }
+              ]
             }
           },
           {
@@ -9076,17 +9061,8 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_type_identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "scoped_type_identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_type_identifier"
           }
         },
         {
@@ -9106,17 +9082,8 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_field_identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "scoped_field_identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_field_identifier"
           }
         },
         {
@@ -9136,17 +9103,8 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "scoped_identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "identifier"
           }
         },
         {
@@ -9385,7 +9343,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "scoped_identifier"
+              "name": "qualified_identifier"
             }
           ]
         },
@@ -10194,7 +10152,46 @@
         ]
       }
     },
-    "scoped_field_identifier": {
+    "dependent_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_function"
+        }
+      ]
+    },
+    "dependent_field_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_method"
+        }
+      ]
+    },
+    "dependent_type_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_type"
+        }
+      ]
+    },
+    "_scope_resolution": {
       "type": "PREC",
       "value": 1,
       "content": {
@@ -10202,7 +10199,7 @@
         "members": [
           {
             "type": "FIELD",
-            "name": "namespace",
+            "name": "scope",
             "content": {
               "type": "CHOICE",
               "members": [
@@ -10218,8 +10215,13 @@
                       "name": "template_type"
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "scoped_namespace_identifier"
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "dependent_type_identifier"
+                      },
+                      "named": true,
+                      "value": "dependent_name"
                     }
                   ]
                 },
@@ -10232,193 +10234,175 @@
           {
             "type": "STRING",
             "value": "::"
-          },
-          {
-            "type": "FIELD",
-            "name": "name",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_field_identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "operator_name"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "destructor_name"
-                }
-              ]
-            }
           }
         ]
       }
     },
-    "scoped_identifier": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "namespace",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_namespace_identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "template_type"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "scoped_namespace_identifier"
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "::"
-          },
-          {
-            "type": "FIELD",
-            "name": "name",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
+    "qualified_field_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_scope_resolution"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "dependent_field_identifier"
                 },
-                {
+                "named": true,
+                "value": "dependent_name"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "SYMBOL",
-                  "name": "operator_name"
+                  "name": "qualified_field_identifier"
                 },
-                {
-                  "type": "SYMBOL",
-                  "name": "destructor_name"
-                }
-              ]
-            }
+                "named": true,
+                "value": "qualified_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "template_method"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_field_identifier"
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
-    "scoped_type_identifier": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "namespace",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_namespace_identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "template_type"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "scoped_namespace_identifier"
-                    }
-                  ]
+    "qualified_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_scope_resolution"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "dependent_identifier"
                 },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "::"
-          },
-          {
-            "type": "FIELD",
-            "name": "name",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_type_identifier"
-            }
+                "named": true,
+                "value": "dependent_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "qualified_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "template_function"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "destructor_name"
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
-    "scoped_namespace_identifier": {
-      "type": "PREC",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "namespace",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_namespace_identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "template_type"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "scoped_namespace_identifier"
-                    }
-                  ]
+    "qualified_type_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_scope_resolution"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "dependent_type_identifier"
                 },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "::"
-          },
-          {
-            "type": "FIELD",
-            "name": "name",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_namespace_identifier"
-            }
+                "named": true,
+                "value": "dependent_name"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "qualified_type_identifier"
+                },
+                "named": true,
+                "value": "qualified_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "template_type"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_type_identifier"
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
+    },
+    "qualified_operator_cast_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_scope_resolution"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "qualified_operator_cast_identifier"
+                },
+                "named": true,
+                "value": "qualified_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator_cast"
+              }
+            ]
+          }
+        }
+      ]
     },
     "operator_name": {
       "type": "PREC",
@@ -10751,20 +10735,24 @@
     ],
     [
       "template_function",
-      "_expression"
+      "template_type",
+      "qualified_identifier"
     ],
     [
       "template_method",
-      "template_type",
       "field_expression"
     ],
     [
-      "scoped_type_identifier",
-      "scoped_identifier"
+      "template_type",
+      "qualified_type_identifier"
     ],
     [
-      "scoped_type_identifier",
-      "scoped_field_identifier"
+      "qualified_type_identifier",
+      "qualified_identifier"
+    ],
+    [
+      "dependent_type_identifier",
+      "dependent_identifier"
     ],
     [
       "comma_expression",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -62,11 +62,11 @@
         "named": true
       },
       {
-        "type": "reference_declarator",
+        "type": "qualified_identifier",
         "named": true
       },
       {
-        "type": "scoped_identifier",
+        "type": "reference_declarator",
         "named": true
       },
       {
@@ -168,11 +168,11 @@
         "named": true
       },
       {
-        "type": "raw_string_literal",
+        "type": "qualified_identifier",
         "named": true
       },
       {
-        "type": "scoped_identifier",
+        "type": "raw_string_literal",
         "named": true
       },
       {
@@ -392,7 +392,7 @@
         "named": true
       },
       {
-        "type": "scoped_type_identifier",
+        "type": "qualified_identifier",
         "named": true
       },
       {
@@ -696,7 +696,7 @@
             "named": true
           },
           {
-            "type": "scoped_namespace_identifier",
+            "type": "qualified_identifier",
             "named": true
           },
           {
@@ -888,7 +888,7 @@
       "required": true,
       "types": [
         {
-          "type": "scoped_type_identifier",
+          "type": "qualified_identifier",
           "named": true
         },
         {
@@ -1252,7 +1252,7 @@
         "required": false,
         "types": [
           {
-            "type": "scoped_type_identifier",
+            "type": "qualified_identifier",
             "named": true
           },
           {
@@ -1380,7 +1380,7 @@
         "required": true,
         "types": [
           {
-            "type": "scoped_type_identifier",
+            "type": "qualified_identifier",
             "named": true
           },
           {
@@ -1814,6 +1814,29 @@
     "fields": {}
   },
   {
+    "type": "dependent_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "template_function",
+          "named": true
+        },
+        {
+          "type": "template_method",
+          "named": true
+        },
+        {
+          "type": "template_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "dependent_type",
     "named": true,
     "fields": {},
@@ -1878,7 +1901,7 @@
         "required": false,
         "types": [
           {
-            "type": "scoped_type_identifier",
+            "type": "qualified_identifier",
             "named": true
           },
           {
@@ -1906,7 +1929,7 @@
         "required": false,
         "types": [
           {
-            "type": "scoped_type_identifier",
+            "type": "qualified_identifier",
             "named": true
           },
           {
@@ -2175,6 +2198,10 @@
         "required": true,
         "types": [
           {
+            "type": "dependent_name",
+            "named": true
+          },
+          {
             "type": "destructor_name",
             "named": true
           },
@@ -2225,7 +2252,7 @@
           "named": true
         },
         {
-          "type": "scoped_field_identifier",
+          "type": "qualified_identifier",
           "named": true
         },
         {
@@ -2405,7 +2432,7 @@
           "named": true
         },
         {
-          "type": "scoped_type_identifier",
+          "type": "qualified_identifier",
           "named": true
         },
         {
@@ -3061,24 +3088,6 @@
         "types": [
           {
             "type": "_abstract_declarator",
-            "named": true
-          }
-        ]
-      },
-      "namespace": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "scoped_namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "template_type",
             "named": true
           }
         ]
@@ -4127,6 +4136,80 @@
     }
   },
   {
+    "type": "qualified_identifier",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "dependent_name",
+            "named": true
+          },
+          {
+            "type": "destructor_name",
+            "named": true
+          },
+          {
+            "type": "field_identifier",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "operator_cast",
+            "named": true
+          },
+          {
+            "type": "operator_name",
+            "named": true
+          },
+          {
+            "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "template_function",
+            "named": true
+          },
+          {
+            "type": "template_method",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      },
+      "scope": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "dependent_name",
+            "named": true
+          },
+          {
+            "type": "namespace_identifier",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "ref_qualifier",
     "named": true,
     "fields": {}
@@ -4175,158 +4258,6 @@
           "named": true
         }
       ]
-    }
-  },
-  {
-    "type": "scoped_field_identifier",
-    "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "destructor_name",
-            "named": true
-          },
-          {
-            "type": "field_identifier",
-            "named": true
-          },
-          {
-            "type": "operator_name",
-            "named": true
-          }
-        ]
-      },
-      "namespace": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "scoped_namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "scoped_identifier",
-    "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "destructor_name",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "operator_name",
-            "named": true
-          }
-        ]
-      },
-      "namespace": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "scoped_namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "scoped_namespace_identifier",
-    "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "namespace_identifier",
-            "named": true
-          }
-        ]
-      },
-      "namespace": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "scoped_namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "scoped_type_identifier",
-    "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "type_identifier",
-            "named": true
-          }
-        ]
-      },
-      "namespace": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "scoped_namespace_identifier",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          }
-        ]
-      }
     }
   },
   {
@@ -4448,7 +4379,7 @@
         "required": false,
         "types": [
           {
-            "type": "scoped_type_identifier",
+            "type": "qualified_identifier",
             "named": true
           },
           {
@@ -4649,10 +4580,6 @@
           {
             "type": "identifier",
             "named": true
-          },
-          {
-            "type": "scoped_identifier",
-            "named": true
           }
         ]
       }
@@ -4734,10 +4661,6 @@
         "types": [
           {
             "type": "field_identifier",
-            "named": true
-          },
-          {
-            "type": "scoped_field_identifier",
             "named": true
           }
         ]
@@ -4835,10 +4758,6 @@
         "multiple": false,
         "required": true,
         "types": [
-          {
-            "type": "scoped_type_identifier",
-            "named": true
-          },
           {
             "type": "type_identifier",
             "named": true
@@ -5166,7 +5085,7 @@
         "required": false,
         "types": [
           {
-            "type": "scoped_type_identifier",
+            "type": "qualified_identifier",
             "named": true
           },
           {
@@ -5277,7 +5196,7 @@
           "named": true
         },
         {
-          "type": "scoped_identifier",
+          "type": "qualified_identifier",
           "named": true
         }
       ]

--- a/test/corpus/ambiguities.txt
+++ b/test/corpus/ambiguities.txt
@@ -29,9 +29,11 @@ int a = std::get<0>(t);
     (init_declarator
       (identifier)
       (call_expression
-        (template_function
-          (scoped_identifier (namespace_identifier) (identifier))
-          (template_argument_list (number_literal)))
+        (qualified_identifier
+          (namespace_identifier)
+          (template_function
+            (identifier)
+            (template_argument_list (number_literal))))
         (argument_list (identifier))))))
 
 =================================================

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -50,17 +50,18 @@ using a = typename b<T>::c;
 
 (translation_unit
   (using_declaration (identifier))
-  (using_declaration (scoped_identifier (identifier)))
-  (using_declaration (scoped_identifier (namespace_identifier) (identifier)))
+  (using_declaration (qualified_identifier (identifier)))
+  (using_declaration (qualified_identifier (namespace_identifier) (identifier)))
   (using_declaration
-    (scoped_identifier
-      (scoped_namespace_identifier
-        (scoped_namespace_identifier (namespace_identifier))
-        (namespace_identifier))
-      (identifier)))
+    (qualified_identifier
+      (qualified_identifier
+        (namespace_identifier)
+        (qualified_identifier
+            (namespace_identifier)
+            (identifier)))))
   (alias_declaration
     (type_identifier)
-    (type_descriptor (scoped_type_identifier (namespace_identifier) (type_identifier))))
+    (type_descriptor (qualified_identifier (namespace_identifier) (type_identifier))))
   (using_declaration (identifier))
   (template_declaration
     (template_parameter_list
@@ -69,7 +70,7 @@ using a = typename b<T>::c;
       (type_identifier)
       (type_descriptor
         (dependent_type
-          (scoped_type_identifier
+          (qualified_identifier
             (template_type (type_identifier) (template_argument_list (type_descriptor (type_identifier))))
             (type_identifier)))))))
 
@@ -285,9 +286,11 @@ class C {
     (function_definition (function_declarator (identifier) (parameter_list))
       (field_initializer_list
         (field_initializer
-          (template_method
-            (scoped_field_identifier (namespace_identifier) (field_identifier))
-            (template_argument_list (type_descriptor (type_identifier))))
+          (qualified_identifier
+            (namespace_identifier) 
+            (template_method
+              (field_identifier)
+              (template_argument_list (type_descriptor (type_identifier)))))
           (argument_list)))
       (compound_statement))
     (declaration (function_declarator (destructor_name (identifier)) (parameter_list))))))
@@ -312,7 +315,7 @@ class C : C::D, public E {
   (class_specifier
     (type_identifier)
     (base_class_clause
-      (scoped_type_identifier (namespace_identifier) (type_identifier))
+      (qualified_identifier (namespace_identifier) (type_identifier))
       (type_identifier))
     (field_declaration_list)))
 
@@ -502,7 +505,7 @@ void * A::operator delete   [](void * p);
       (parameter_list
         (parameter_declaration (type_qualifier) (primitive_type) (pointer_declarator (identifier))))))
   (declaration
-    (scoped_type_identifier (namespace_identifier) (type_identifier))
+    (qualified_identifier (namespace_identifier) (type_identifier))
     (function_declarator
       (operator_name (identifier))
       (parameter_list
@@ -510,14 +513,14 @@ void * A::operator delete   [](void * p);
   (declaration
     (primitive_type)
     (function_declarator
-      (scoped_identifier (namespace_identifier) (operator_name))
+      (qualified_identifier (namespace_identifier) (operator_name))
       (parameter_list
         (parameter_declaration (type_qualifier) (type_identifier) (reference_declarator (identifier))))
       (type_qualifier)))
   (declaration
     (primitive_type)
     (function_declarator
-      (scoped_identifier (namespace_identifier) (operator_name))
+      (qualified_identifier (namespace_identifier) (operator_name))
       (parameter_list
         (parameter_declaration (type_qualifier) (type_identifier) (reference_declarator (identifier))))
       (type_qualifier)))
@@ -525,13 +528,13 @@ void * A::operator delete   [](void * p);
      (primitive_type)
      (pointer_declarator
        (function_declarator
-         (scoped_identifier (namespace_identifier) (operator_name))
+         (qualified_identifier (namespace_identifier) (operator_name))
          (parameter_list (parameter_declaration (primitive_type) (identifier))))))
    (declaration
      (primitive_type)
      (pointer_declarator
        (function_declarator
-         (scoped_identifier (namespace_identifier) (operator_name))
+         (qualified_identifier (namespace_identifier) (operator_name))
          (parameter_list (parameter_declaration (primitive_type) (pointer_declarator (identifier))))))))
 
 =========================================
@@ -585,7 +588,7 @@ void A<T>::foo(U&) {}
       (type_parameter_declaration (type_identifier)))
     (function_definition
       (function_declarator
-        (scoped_identifier
+        (qualified_identifier
           (template_type
             (type_identifier)
             (template_argument_list (type_descriptor (type_identifier))))
@@ -606,7 +609,7 @@ void A<T>::foo(U&) {}
       (function_definition
         (primitive_type)
         (function_declarator
-          (scoped_identifier
+          (qualified_identifier
             (template_type
               (type_identifier)
               (template_argument_list (type_descriptor (type_identifier))))
@@ -693,9 +696,11 @@ struct foo::bar<T> {};
   (template_declaration
     (template_parameter_list)
     (struct_specifier
-      (template_type
-        (scoped_type_identifier (namespace_identifier) (type_identifier))
-        (template_argument_list (type_descriptor (type_identifier))))
+      (qualified_identifier
+        (namespace_identifier)
+        (template_type
+          (type_identifier)
+          (template_argument_list (type_descriptor (type_identifier)))))
       (field_declaration_list))))
 
 ====================================================
@@ -766,12 +771,12 @@ class Y
     parameters: (template_parameter_list
       (optional_type_parameter_declaration
         name: (type_identifier)
-        default_type: (template_type
-          name: (scoped_type_identifier
-            namespace: (namespace_identifier)
-            name: (type_identifier))
-          arguments: (template_argument_list
-            (type_descriptor type: (primitive_type))))))
+        default_type: (qualified_identifier
+            scope: (namespace_identifier)
+            name: (template_type
+              name: (type_identifier)
+              arguments: (template_argument_list
+                (type_descriptor type: (primitive_type)))))))
     (class_specifier
       name: (type_identifier)
       body: (field_declaration_list)))
@@ -799,32 +804,32 @@ class X
     parameters: (template_parameter_list
       (type_parameter_declaration (type_identifier))
       (optional_parameter_declaration
-        type: (dependent_type (scoped_type_identifier
-          namespace: (template_type
-            name: (scoped_type_identifier
-              namespace: (namespace_identifier)
-              name: (type_identifier))
-            arguments: (template_argument_list
-              (binary_expression
-                left: (unary_expression
-                  argument: (compound_literal_expression
-                    type: (template_type
-                      name: (type_identifier)
-                      arguments: (template_argument_list (type_descriptor type: (type_identifier))))
-                    value: (initializer_list)))
-                right: (parenthesized_expression
-                  (binary_expression
-                    left: (compound_literal_expression
+        type: (dependent_type (qualified_identifier
+          scope: (namespace_identifier)
+          name:  (qualified_identifier
+            scope: (template_type
+              name: (type_identifier)
+              arguments: (template_argument_list
+                (binary_expression
+                  left: (unary_expression
+                    argument: (compound_literal_expression
                       type: (template_type
                         name: (type_identifier)
                         arguments: (template_argument_list (type_descriptor type: (type_identifier))))
-                      value: (initializer_list))
-                    right: (compound_literal_expression
-                      type: (template_type
-                        name: (type_identifier)
-                        arguments: (template_argument_list (type_descriptor type: (type_identifier))))
-                      value: (initializer_list)))))))
-          name: (type_identifier)))
+                      value: (initializer_list)))
+                  right: (parenthesized_expression
+                    (binary_expression
+                      left: (compound_literal_expression
+                        type: (template_type
+                          name: (type_identifier)
+                          arguments: (template_argument_list (type_descriptor type: (type_identifier))))
+                        value: (initializer_list))
+                      right: (compound_literal_expression
+                        type: (template_type
+                          name: (type_identifier)
+                          arguments: (template_argument_list (type_descriptor type: (type_identifier))))
+                        value: (initializer_list)))))))
+        name: (type_identifier))))
       default_value: (number_literal)))
     (class_specifier
       name: (type_identifier)
@@ -868,7 +873,7 @@ template A<int, bool>::A(char *, size_t);
 (translation_unit
   (template_instantiation
     (function_declarator
-      (scoped_identifier
+      (qualified_identifier
         (template_type
           (type_identifier)
           (template_argument_list
@@ -914,8 +919,8 @@ int main() {
           declarator: (reference_declarator
             (structured_binding_declarator (identifier) (identifier)))
           value: (call_expression
-            function: (scoped_identifier
-              namespace: (namespace_identifier)
+            function: (qualified_identifier
+              scope: (namespace_identifier)
               name: (identifier))
             arguments: (argument_list (identifier)))))
       (declaration
@@ -1007,7 +1012,7 @@ class TT {
         (template_declaration
           (template_parameter_list
             (variadic_parameter_declaration
-              (scoped_type_identifier
+              (qualified_identifier
                 (namespace_identifier)
                 (type_identifier))
               (variadic_declarator)))
@@ -1038,8 +1043,8 @@ enum struct Foo : char { };
   (enum_specifier (type_identifier) (type_identifier) (enumerator_list))
   (enum_specifier (type_identifier) (sized_type_specifier (primitive_type)) (enumerator_list))
   (enum_specifier (enumerator_list (enumerator (identifier)) (enumerator (identifier))))
-  (enum_specifier (type_identifier) (scoped_type_identifier (namespace_identifier) (type_identifier)) (enumerator_list))
-  (enum_specifier (scoped_type_identifier (namespace_identifier) (type_identifier)) (scoped_type_identifier (namespace_identifier) (type_identifier)) (enumerator_list))
+  (enum_specifier (type_identifier) (qualified_identifier (namespace_identifier) (type_identifier)) (enumerator_list))
+  (enum_specifier (qualified_identifier (namespace_identifier) (type_identifier)) (qualified_identifier (namespace_identifier) (type_identifier)) (enumerator_list))
   (enum_specifier (type_identifier))
   (enum_specifier (type_identifier) (type_identifier) (enumerator_list)))
 
@@ -1071,15 +1076,14 @@ static_assert(true, R"FOO(string)FOO");
       (static_assert_declaration
         condition: (false))))
   (static_assert_declaration
-    condition: (scoped_identifier
-    namespace: (template_type
-      name: (scoped_type_identifier
-      namespace: (namespace_identifier)
-      name: (type_identifier))
-      arguments: (template_argument_list
-      (type_descriptor
-        type: (type_identifier))))
-    name: (identifier)))
+    condition: (qualified_identifier
+      scope: (namespace_identifier)
+      name: (qualified_identifier
+        scope: (template_type
+          name: (type_identifier)
+          arguments: (template_argument_list
+            (type_descriptor type: (type_identifier))))
+        name: (identifier))))
   (static_assert_declaration
     condition: (true)
     message: (concatenated_string (string_literal) (string_literal)))
@@ -1129,9 +1133,13 @@ operator T*();
     (virtual_function_specifier)
     (operator_cast (type_identifier) (abstract_function_declarator (parameter_list))) (number_literal))
   (declaration
-    (operator_cast
-      (scoped_namespace_identifier (namespace_identifier) (namespace_identifier))
-      (type_identifier) (abstract_function_declarator (parameter_list))))
+    (qualified_identifier
+      (namespace_identifier)
+      (qualified_identifier
+        (namespace_identifier)
+        (operator_cast
+          (type_identifier)
+          (abstract_function_declarator (parameter_list))))))
   (template_declaration
     (template_parameter_list (type_parameter_declaration (type_identifier)))
     (declaration (operator_cast
@@ -1140,6 +1148,68 @@ operator T*();
   (declaration
     (attribute_declaration (attribute (identifier)))
     (operator_cast (primitive_type) (abstract_pointer_declarator (abstract_function_declarator (parameter_list))))))
+
+=========================================
+Class scope cast operator overload declarations
+=========================================
+
+class A {
+  operator int() const {}
+  explicit operator int*() const;
+  operator arr_t*();
+  operator B&();
+  operator auto() const;
+  virtual operator A() = 0;
+  A::B::operator C();
+  template <typename T>
+  operator T*();
+  [[nodiscard]] operator char *();
+};
+
+---
+
+(translation_unit
+  (class_specifier (type_identifier) (field_declaration_list
+    (function_definition
+      (operator_cast
+        (primitive_type)
+        (abstract_function_declarator (parameter_list) (type_qualifier)))
+      (compound_statement))
+    (declaration
+      (explicit_function_specifier)
+      (operator_cast
+        (primitive_type)
+        (abstract_pointer_declarator (abstract_function_declarator (parameter_list) (type_qualifier)))))
+    (declaration
+      (operator_cast
+        (type_identifier)
+        (abstract_pointer_declarator (abstract_function_declarator (parameter_list)))))
+    (declaration (operator_cast
+      (type_identifier)
+      (abstract_reference_declarator (abstract_function_declarator (parameter_list)))))
+    (declaration
+      (operator_cast
+        (auto)
+        (abstract_function_declarator (parameter_list) (type_qualifier))))
+    (declaration
+      (virtual_function_specifier)
+      (operator_cast (type_identifier) (abstract_function_declarator (parameter_list))) (number_literal))
+    (declaration
+      (qualified_identifier
+        (namespace_identifier)
+        (qualified_identifier
+          (namespace_identifier)
+          (operator_cast
+            (type_identifier)
+            (abstract_function_declarator (parameter_list))))))
+    (template_declaration
+      (template_parameter_list (type_parameter_declaration (type_identifier)))
+      (declaration (operator_cast
+        (type_identifier)
+        (abstract_pointer_declarator (abstract_function_declarator (parameter_list))))))
+    (declaration
+      (attribute_declaration (attribute (identifier)))
+      (operator_cast (primitive_type) (abstract_pointer_declarator (abstract_function_declarator (parameter_list))))))))
 
 =========================
 Function declarations
@@ -1238,7 +1308,7 @@ void C::f() & noexcept {}
   (declaration
     (primitive_type)
     (function_declarator
-      (scoped_identifier
+      (qualified_identifier
         (namespace_identifier)
         (identifier))
       (parameter_list)
@@ -1246,7 +1316,7 @@ void C::f() & noexcept {}
   (declaration
     (primitive_type)
     (function_declarator
-      (scoped_identifier
+      (qualified_identifier
         (namespace_identifier)
         (identifier))
       (parameter_list)
@@ -1255,7 +1325,7 @@ void C::f() & noexcept {}
   (function_definition
     (primitive_type)
     (function_declarator
-      (scoped_identifier
+      (qualified_identifier
         (namespace_identifier)
         (identifier))
       (parameter_list)
@@ -1264,7 +1334,7 @@ void C::f() & noexcept {}
   (function_definition
     (primitive_type)
     (function_declarator
-      (scoped_identifier
+      (qualified_identifier
         (namespace_identifier)
         (identifier))
       (parameter_list)

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -11,13 +11,13 @@ int T::foo() const { return 0; }
   (function_definition
     (primitive_type)
     (function_declarator
-      (scoped_identifier (namespace_identifier) (identifier))
+      (qualified_identifier (namespace_identifier) (identifier))
       (parameter_list))
     (compound_statement (return_statement (number_literal))))
   (function_definition
     (primitive_type)
     (function_declarator
-      (scoped_identifier (namespace_identifier) (identifier))
+      (qualified_identifier (namespace_identifier) (identifier))
       (parameter_list)
       (type_qualifier))
     (compound_statement (return_statement (number_literal)))))
@@ -39,12 +39,12 @@ T::T() : Base<T>() {}
 (translation_unit
   (function_definition
     (function_declarator
-      (scoped_identifier (namespace_identifier) (identifier))
+      (qualified_identifier (namespace_identifier) (identifier))
       (parameter_list))
     (compound_statement))
   (function_definition
     (function_declarator
-      (scoped_identifier (namespace_identifier) (identifier))
+      (qualified_identifier (namespace_identifier) (identifier))
       (parameter_list))
     (field_initializer_list
       (field_initializer (field_identifier) (argument_list (number_literal)))
@@ -53,7 +53,7 @@ T::T() : Base<T>() {}
       (expression_statement (call_expression (identifier) (argument_list (string_literal))))))
   (function_definition
     (function_declarator
-      (scoped_identifier (namespace_identifier) (identifier))
+      (qualified_identifier (namespace_identifier) (identifier))
       (parameter_list))
     (field_initializer_list
       (field_initializer
@@ -173,5 +173,5 @@ T::~T() {}
     (compound_statement))
   (function_definition
     (function_declarator
-      (scoped_identifier (namespace_identifier) (destructor_name (identifier))) (parameter_list))
+      (qualified_identifier (namespace_identifier) (destructor_name (identifier))) (parameter_list))
     (compound_statement)))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -13,7 +13,7 @@ int main() {
   (function_declarator (identifier) (parameter_list))
   (compound_statement
     (expression_statement (call_expression
-      (scoped_identifier (namespace_identifier) (identifier))
+      (qualified_identifier (namespace_identifier) (identifier))
       (argument_list
         (string_literal)
         (string_literal)))))))
@@ -99,11 +99,13 @@ int main() {
         (init_declarator
           (identifier)
           (new_expression
-            (template_type
-              (scoped_type_identifier (namespace_identifier) (type_identifier))
-              (template_argument_list
-                (type_descriptor (type_identifier))
-                (type_descriptor (type_identifier))))
+            (qualified_identifier
+              (namespace_identifier)
+              (template_type
+                (type_identifier)
+                (template_argument_list
+                  (type_descriptor (type_identifier))
+                  (type_descriptor (type_identifier)))))
             (initializer_list))))
       (declaration
         (auto)
@@ -207,28 +209,81 @@ Nested template calls
 ====================================================
 
 class A {
+  A() : T::template Nested<int>::type() {}
+  A() : T::template Nested<int>::template Nested2<float>::type() {}
+
   B<C::D<E, F>>::G field;
+  using B<C>::template D<int>;
 
   H<I<J>> method() {
     K::L<M<N>> variable1 = K::L<M<N>>{};
+    typename K::template L<M<N>>::type variable2;
+    typename K::template L<M<N>>::template O<P>::type variable3;
   }
+
+  typename Z::template Nested<int>::type x;
+  typename X::template Nested<int>::Y::template Nested2<D> x;
 };
 
 ---
 
 (translation_unit
   (class_specifier (type_identifier) (field_declaration_list
+    (function_definition
+      (function_declarator (identifier) (parameter_list))
+      (field_initializer_list
+        (field_initializer
+          (qualified_identifier
+            (namespace_identifier)
+            (qualified_identifier
+              (dependent_name
+                (template_type
+                  (type_identifier)
+                  (template_argument_list (type_descriptor (primitive_type)))))
+              (field_identifier)))
+          (argument_list)))
+      (compound_statement))
+    (function_definition
+      (function_declarator (identifier) (parameter_list))
+      (field_initializer_list
+        (field_initializer
+          (qualified_identifier
+            (namespace_identifier)
+            (qualified_identifier
+              (dependent_name
+                (template_type
+                  (type_identifier)
+                  (template_argument_list (type_descriptor (primitive_type)))))
+              (qualified_identifier
+                (dependent_name
+                  (template_type
+                    (type_identifier)
+                    (template_argument_list (type_descriptor (primitive_type)))))
+                (field_identifier))))
+          (argument_list)))
+      (compound_statement))
     (field_declaration
-      (scoped_type_identifier
+      (qualified_identifier
         (template_type
           (type_identifier)
           (template_argument_list
-            (type_descriptor (template_type
-              (scoped_type_identifier (namespace_identifier) (type_identifier))
-              (template_argument_list
-                (type_descriptor (type_identifier)) (type_descriptor (type_identifier)))))))
+            (type_descriptor (qualified_identifier
+              (namespace_identifier)
+              (template_type
+                (type_identifier)
+                (template_argument_list
+                  (type_descriptor (type_identifier)) (type_descriptor (type_identifier))))))))
         (type_identifier))
       (field_identifier))
+    (using_declaration
+      (qualified_identifier
+        (template_type
+          (type_identifier)
+          (template_argument_list (type_descriptor (type_identifier))))
+        (dependent_name
+          (template_function
+            (identifier)
+            (template_argument_list (type_descriptor (primitive_type)))))))
     (function_definition
       (template_type
         (type_identifier)
@@ -239,20 +294,82 @@ class A {
       (function_declarator (field_identifier) (parameter_list))
       (compound_statement
         (declaration
-          (template_type
-            (scoped_type_identifier (namespace_identifier) (type_identifier))
-            (template_argument_list (type_descriptor
-              (template_type (type_identifier) (template_argument_list (type_descriptor (type_identifier)))))))
+          (qualified_identifier
+            (namespace_identifier)
+            (template_type
+              (type_identifier)
+              (template_argument_list (type_descriptor
+                (template_type
+                  (type_identifier)
+                  (template_argument_list (type_descriptor (type_identifier))))))))
           (init_declarator
             (identifier)
             (compound_literal_expression
-              (template_type
-                (scoped_type_identifier (namespace_identifier) (type_identifier))
-                (template_argument_list (type_descriptor
+              (qualified_identifier
+                (namespace_identifier)
+                (template_type
+                  (type_identifier)
+                  (template_argument_list (type_descriptor
+                    (template_type
+                      (type_identifier)
+                      (template_argument_list (type_descriptor (type_identifier))))))))
+              (initializer_list))))
+        (declaration
+          (dependent_type
+            (qualified_identifier
+              (namespace_identifier)
+              (qualified_identifier
+                (dependent_name
                   (template_type
                     (type_identifier)
-                    (template_argument_list (type_descriptor (type_identifier)))))))
-              (initializer_list)))))))))
+                    (template_argument_list (type_descriptor (template_type (type_identifier)
+                      (template_argument_list (type_descriptor (type_identifier))))))))
+                (type_identifier))))
+          (identifier))
+        (declaration
+          (dependent_type
+            (qualified_identifier
+              (namespace_identifier)
+              (qualified_identifier
+                (dependent_name
+                  (template_type
+                    (type_identifier)
+                    (template_argument_list (type_descriptor (template_type (type_identifier)
+                      (template_argument_list (type_descriptor (type_identifier))))))))
+                (qualified_identifier
+                  (dependent_name
+                    (template_type
+                      (type_identifier)
+                      (template_argument_list (type_descriptor (type_identifier)))))
+                  (type_identifier)))))
+          (identifier))))
+    (field_declaration
+      (dependent_type
+        (qualified_identifier
+          (namespace_identifier)
+          (qualified_identifier
+            (dependent_name
+              (template_type
+                (type_identifier)
+                (template_argument_list (type_descriptor (primitive_type)))))
+            (type_identifier))))
+      (field_identifier))
+    (field_declaration
+      (dependent_type
+        (qualified_identifier
+          (namespace_identifier)
+          (qualified_identifier
+            (dependent_name
+              (template_type
+                (type_identifier)
+                (template_argument_list (type_descriptor (primitive_type)))))
+            (qualified_identifier
+              (namespace_identifier)
+              (dependent_name
+                (template_type
+                  (type_identifier)
+                  (template_argument_list (type_descriptor (type_identifier)))))))))
+      (field_identifier)))))
 
 ====================================================
 Comma expressions at the start of blocks
@@ -360,6 +477,10 @@ int main() {
 
   // '<' and '>' as binary operators
   if (a < b && c >= d) {}
+
+  Q::template R<S>();
+  this->template f<T>();
+  foo.template f<U>();
 }
 ---
 
@@ -383,7 +504,34 @@ int main() {
         (binary_expression
           (binary_expression (identifier) (identifier))
           (binary_expression (identifier) (identifier))))
-      (compound_statement)))))
+      (compound_statement))
+    (expression_statement
+      (call_expression
+        (qualified_identifier
+          (namespace_identifier)
+          (dependent_name
+            (template_function
+              (identifier)
+              (template_argument_list (type_descriptor (type_identifier))))))
+        (argument_list)))
+    (expression_statement
+      (call_expression
+        (field_expression
+          (this)
+          (dependent_name
+            (template_method
+              (field_identifier)
+              (template_argument_list (type_descriptor (type_identifier))))))
+      (argument_list)))
+    (expression_statement
+      (call_expression
+        (field_expression
+          (identifier)
+          (dependent_name
+            (template_method
+              (field_identifier)
+              (template_argument_list (type_descriptor (type_identifier))))))
+      (argument_list))))))
 
 ====================================================
 Parameter pack expansions
@@ -542,8 +690,8 @@ void f(T...) {}
           pattern: (parenthesized_expression
             (comma_expression
               left: (binary_expression
-                left: (scoped_identifier
-                  namespace: (namespace_identifier)
+                left: (qualified_identifier
+                  scope: (namespace_identifier)
                   name: (identifier))
                 right: (identifier))
               right: (number_literal)))))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -91,12 +91,12 @@ T f() {
     body: (compound_statement
       (if_statement
         condition: (condition_clause
-          value: (template_function
-            name: (scoped_identifier
-              namespace: (namespace_identifier)
-              name: (identifier))
-            arguments: (template_argument_list
-              (type_descriptor type: (type_identifier)))))
+          value: (qualified_identifier
+            scope: (namespace_identifier)
+            name: (template_function
+              name: (identifier)
+              arguments: (template_argument_list
+                (type_descriptor type: (type_identifier))))))
         consequence: (return_statement
           (pointer_expression argument: (identifier)))
         alternative: (return_statement (identifier))))))
@@ -176,7 +176,7 @@ void main() {
         (compound_statement
           (expression_statement (call_expression (identifier) (argument_list))))
         (catch_clause
-          (parameter_list (parameter_declaration (type_qualifier) (scoped_type_identifier (namespace_identifier) (type_identifier))))
+          (parameter_list (parameter_declaration (type_qualifier) (qualified_identifier (namespace_identifier) (type_identifier))))
           (compound_statement (comment)))
         (catch_clause
           (parameter_list (parameter_declaration (type_qualifier) (type_identifier) (reference_declarator (identifier))))
@@ -260,7 +260,7 @@ void foo() throw(float) { }
     (primitive_type)
     (function_declarator (identifier) (parameter_list)
       (throw_specifier
-        (type_descriptor (scoped_type_identifier (namespace_identifier) (type_identifier)))
+        (type_descriptor (qualified_identifier (namespace_identifier) (type_identifier)))
         (type_descriptor (primitive_type) (abstract_pointer_declarator)))))
   (function_definition
     (primitive_type)
@@ -279,9 +279,11 @@ a::b::c = 1;
 (translation_unit
   (expression_statement
     (assignment_expression
-      (scoped_namespace_identifier
-        (scoped_namespace_identifier (namespace_identifier) (namespace_identifier))
-        (namespace_identifier))
+      (qualified_identifier
+        (namespace_identifier)
+        (qualified_identifier
+          (namespace_identifier)
+          (identifier)))
       (number_literal))))
 
 =========================================

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -26,14 +26,16 @@ std::vector<int>::size_typ my_string;
 
 (translation_unit
   (declaration
-    (scoped_type_identifier (namespace_identifier) (type_identifier))
+    (qualified_identifier (namespace_identifier) (type_identifier))
     (identifier))
   (declaration
-    (scoped_type_identifier
-      (template_type
-        (scoped_type_identifier (namespace_identifier) (type_identifier))
-        (template_argument_list (type_descriptor (primitive_type))))
-      (type_identifier))
+    (qualified_identifier
+      (namespace_identifier)
+      (qualified_identifier
+        (template_type
+          (type_identifier)
+          (template_argument_list (type_descriptor (primitive_type))))
+        (type_identifier)))
     (identifier)))
 
 ==========================================
@@ -57,7 +59,7 @@ struct X : B<T>
         (template_type (type_identifier) (template_argument_list (type_descriptor (type_identifier)))))
       (field_declaration_list
         (field_declaration
-          (dependent_type (scoped_type_identifier (namespace_identifier) (type_identifier)))
+          (dependent_type (qualified_identifier (namespace_identifier) (type_identifier)))
           (pointer_declarator (field_identifier)))))))
 
 ==========================================
@@ -82,22 +84,26 @@ typedef std::function<void(int)> b;
 
 (translation_unit
   (type_definition
-    (template_type
-      (scoped_type_identifier (namespace_identifier) (type_identifier))
-      (template_argument_list
-        (type_descriptor
-          (type_identifier)
-          (abstract_function_declarator (parameter_list
-            (parameter_declaration (primitive_type)))))))
+    (qualified_identifier
+      (namespace_identifier)
+      (template_type
+        (type_identifier)
+        (template_argument_list
+          (type_descriptor
+            (type_identifier)
+            (abstract_function_declarator (parameter_list
+              (parameter_declaration (primitive_type))))))))
     (type_identifier))
   (type_definition
-    (template_type
-      (scoped_type_identifier (namespace_identifier) (type_identifier))
-      (template_argument_list
-        (type_descriptor
-          (primitive_type)
-          (abstract_function_declarator (parameter_list
-            (parameter_declaration (primitive_type)))))))
+    (qualified_identifier
+      (namespace_identifier)
+      (template_type
+        (type_identifier)
+        (template_argument_list
+          (type_descriptor
+            (primitive_type)
+            (abstract_function_declarator (parameter_list
+              (parameter_declaration (primitive_type))))))))
     (type_identifier)))
 
 ====================================================
@@ -145,7 +151,7 @@ auto a::foo() const -> const A<B>& {}
   (function_definition
     (auto)
     (function_declarator
-      (scoped_identifier (namespace_identifier) (identifier))
+      (qualified_identifier (namespace_identifier) (identifier))
       (parameter_list)
       (type_qualifier)
       (trailing_return_type


### PR DESCRIPTION
!! Breaking change due to restructuring and renaming of scoped identifiers !!

Scoped identifier rules have been renamed to "qualified_x_identifier" and all variants are aliased so they appear as simply "qualified_identifier" in the syntax tree. This name better reflects the c++ standard's language describing this concept.

Qualified identifier rules are now always the "parent" with a right associative rule that lets them nest indefinitely. Each rule terminates with some kind of non-scope identifier.

This commit also adds support for the 'template' keyword where required to disambiguate dependent template names. Field accessors (., ->) can be followed by keyword template before a template method. The scope resolution operator can be immediately followed by the 'template' keyword to indicate the following dependent name with '<' is actually a template and shouldn't be parsed as a binary operator. These keywords are required for dependent names in these contexts.

https://en.cppreference.com/w/cpp/language/identifiers#Qualified_identifiers
https://en.cppreference.com/w/cpp/language/dependent_name