### PR TITLE
Add support for constraints on placeholder type specifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -57,6 +57,18 @@ module.exports = grammar(C, {
 
     // Types
 
+    placeholder_type_specifier: $ => seq(
+      field('constraint', optional($._type_specifier)),
+      choice($.auto, $.decltype_auto)
+    ),
+
+    auto: $ => 'auto',
+    decltype_auto: $ => seq(
+      'decltype',
+      '(',
+      $.auto,
+      ')'
+    ),
     decltype: $ => seq(
       'decltype',
       '(',
@@ -72,8 +84,8 @@ module.exports = grammar(C, {
       $.sized_type_specifier,
       $.primitive_type,
       $.template_type,
-      $.auto,
       $.dependent_type,
+      $.placeholder_type_specifier,
       $.decltype,
       prec.right(choice(
         alias($.qualified_type_identifier, $.qualified_identifier),
@@ -202,12 +214,10 @@ module.exports = grammar(C, {
       'thread_local',
     ),
 
-    auto: $ => 'auto',
-
-    dependent_type: $ => prec.dynamic(-1, seq(
+    dependent_type: $ => prec.dynamic(-1, prec.right(seq(
       'typename',
       $._type_specifier
-    )),
+    ))),
 
     // Declarations
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3415,11 +3415,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "auto"
+          "name": "dependent_type"
         },
         {
           "type": "SYMBOL",
-          "name": "dependent_type"
+          "name": "placeholder_type_specifier"
         },
         {
           "type": "SYMBOL",
@@ -7469,6 +7469,65 @@
         ]
       }
     },
+    "placeholder_type_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "constraint",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_type_specifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "auto"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "decltype_auto"
+            }
+          ]
+        }
+      ]
+    },
+    "auto": {
+      "type": "STRING",
+      "value": "auto"
+    },
+    "decltype_auto": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "decltype"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "auto"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "decltype": {
       "type": "SEQ",
       "members": [
@@ -7832,25 +7891,25 @@
         ]
       }
     },
-    "auto": {
-      "type": "STRING",
-      "value": "auto"
-    },
     "dependent_type": {
       "type": "PREC_DYNAMIC",
       "value": -1,
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "typename"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_type_specifier"
-          }
-        ]
+        "type": "PREC_RIGHT",
+        "value": 0,
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "typename"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_type_specifier"
+            }
+          ]
+        }
       }
     },
     "template_declaration": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -376,10 +376,6 @@
     "named": true,
     "subtypes": [
       {
-        "type": "auto",
-        "named": true
-      },
-      {
         "type": "class_specifier",
         "named": true
       },
@@ -393,6 +389,10 @@
       },
       {
         "type": "enum_specifier",
+        "named": true
+      },
+      {
+        "type": "placeholder_type_specifier",
         "named": true
       },
       {
@@ -1856,6 +1856,21 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "decltype_auto",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "auto",
           "named": true
         }
       ]
@@ -3488,6 +3503,36 @@
         },
         {
           "type": "preproc_defined",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "placeholder_type_specifier",
+    "named": true,
+    "fields": {
+      "constraint": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_type_specifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "auto",
+          "named": true
+        },
+        {
+          "type": "decltype_auto",
           "named": true
         }
       ]

--- a/test/corpus/concepts.txt
+++ b/test/corpus/concepts.txt
@@ -340,3 +340,96 @@ requires(T a, size_t n) {
                   (new_declarator
                     (identifier)))))
             (comment)))))))
+
+================================================================================
+Constraints
+================================================================================
+
+template <EqualityComparable T>
+void f(const T&); // constrained function template declaration
+
+void f(const EqualityComparable auto&); // constrained function template declaration
+
+Sortable auto foo = f();
+Sortable<T> auto bar = g();
+NS::Concept<T> auto baz = h();
+
+Sortable decltype(auto) foo = i();
+
+---
+
+(translation_unit
+  (template_declaration
+    (template_parameter_list
+      (parameter_declaration
+        (type_identifier)
+        (identifier)))
+    (declaration
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list
+          (parameter_declaration
+            (type_qualifier)
+            (type_identifier)
+            (abstract_reference_declarator))))))
+  (comment)
+  (declaration
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (type_qualifier)
+          (placeholder_type_specifier
+            (type_identifier)
+            (auto))
+          (abstract_reference_declarator)))))
+  (comment)
+  (declaration
+    (placeholder_type_specifier
+      (type_identifier)
+      (auto))
+    (init_declarator
+      (identifier)
+      (call_expression
+        (identifier)
+        (argument_list))))
+  (declaration
+    (placeholder_type_specifier
+      (template_type
+        (type_identifier)
+        (template_argument_list
+          (type_descriptor
+            (type_identifier))))
+      (auto))
+    (init_declarator
+      (identifier)
+      (call_expression
+        (identifier)
+        (argument_list))))
+  (declaration
+    (placeholder_type_specifier
+      (qualified_identifier
+        (namespace_identifier)
+        (template_type
+          (type_identifier)
+          (template_argument_list
+            (type_descriptor
+              (type_identifier)))))
+      (auto))
+    (init_declarator
+      (identifier)
+      (call_expression
+        (identifier)
+        (argument_list))))
+  (declaration
+    (placeholder_type_specifier
+      (type_identifier)
+      (decltype_auto
+        (auto)))
+    (init_declarator
+      (identifier)
+      (call_expression
+        (identifier)
+        (argument_list)))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -956,7 +956,7 @@ int main() {
 
 (translation_unit
   (declaration
-    type: (auto)
+    type: (placeholder_type_specifier (auto))
     declarator: (init_declarator
       declarator: (structured_binding_declarator (identifier))
       value: (compound_literal_expression
@@ -969,7 +969,7 @@ int main() {
       parameters: (parameter_list))
     body: (compound_statement
       (declaration
-        type: (auto)
+        type: (placeholder_type_specifier (auto))
         declarator: (init_declarator
           declarator: (reference_declarator
             (structured_binding_declarator (identifier) (identifier)))
@@ -980,13 +980,13 @@ int main() {
             arguments: (argument_list (identifier)))))
       (declaration
         (type_qualifier)
-        type: (auto)
+        type: (placeholder_type_specifier (auto))
         declarator: (init_declarator
           declarator: (structured_binding_declarator (identifier) (identifier))
           value: (initializer_list (number_literal) (number_literal))))
       (for_range_loop
         (type_qualifier)
-        type: (auto)
+        type: (placeholder_type_specifier (auto))
         declarator: (reference_declarator (structured_binding_declarator
           (identifier)
           (identifier)))
@@ -1182,7 +1182,7 @@ operator T*();
     (abstract_reference_declarator (abstract_function_declarator (parameter_list)))))
   (declaration
     (operator_cast
-      (auto)
+      (placeholder_type_specifier (auto))
       (abstract_function_declarator (parameter_list) (type_qualifier))))
   (declaration
     (virtual_function_specifier)
@@ -1244,7 +1244,7 @@ class A {
       (abstract_reference_declarator (abstract_function_declarator (parameter_list)))))
     (declaration
       (operator_cast
-        (auto)
+        (placeholder_type_specifier (auto))
         (abstract_function_declarator (parameter_list) (type_qualifier))))
     (declaration
       (virtual_function_specifier)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -90,12 +90,12 @@ int main() {
     (function_declarator (identifier) (parameter_list))
     (compound_statement
       (declaration
-        (auto)
+        (placeholder_type_specifier (auto))
         (init_declarator
           (identifier)
           (new_expression (type_identifier) (argument_list))))
       (declaration
-        (auto)
+        (placeholder_type_specifier (auto))
         (init_declarator
           (identifier)
           (new_expression
@@ -108,14 +108,14 @@ int main() {
                   (type_descriptor (type_identifier)))))
             (initializer_list))))
       (declaration
-        (auto)
+        (placeholder_type_specifier (auto))
         (init_declarator
           (identifier)
           (new_expression
             (argument_list (pointer_expression (identifier)))
             (type_identifier))))
       (declaration
-        (auto)
+        (placeholder_type_specifier (auto))
         (init_declarator
           (identifier)
           (new_expression
@@ -123,7 +123,7 @@ int main() {
             (new_declarator (number_literal) (new_declarator (number_literal)))
             (argument_list))))
       (declaration
-        (auto)
+        (placeholder_type_specifier (auto))
         (init_declarator
           (identifier)
           (new_expression (primitive_type) (new_declarator (number_literal)))))
@@ -178,7 +178,7 @@ auto h = [] {
 
 (translation_unit
   (declaration
-    (auto)
+    (placeholder_type_specifier (auto))
     (init_declarator
       (identifier)
       (lambda_expression
@@ -188,7 +188,7 @@ auto h = [] {
           (trailing_return_type (primitive_type)))
         (compound_statement (return_statement (true))))))
   (declaration
-    (auto)
+    (placeholder_type_specifier (auto))
     (init_declarator
       (identifier)
       (lambda_expression
@@ -197,7 +197,7 @@ auto h = [] {
           (parameter_list (parameter_declaration (primitive_type) (identifier))))
         (compound_statement (return_statement (false))))))
   (declaration
-    (auto)
+    (placeholder_type_specifier (auto))
     (init_declarator
       (identifier)
       (lambda_expression
@@ -696,7 +696,7 @@ void f(T...) {}
                 right: (identifier))
               right: (number_literal)))))))
   (declaration
-    type: (auto)
+    type: (placeholder_type_specifier (auto))
     declarator: (init_declarator
       declarator: (identifier)
       value: (lambda_expression

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -52,7 +52,7 @@ T main() {
             right: (identifier)))))
       (for_range_loop
         (type_qualifier)
-        type: (auto)
+        type: (placeholder_type_specifier (auto))
         declarator: (reference_declarator (identifier))
         right: (identifier)
         body: (compound_statement
@@ -61,7 +61,7 @@ T main() {
             right: (identifier)))))
       (for_range_loop
         (type_qualifier)
-        type: (auto)
+        type: (placeholder_type_specifier (auto))
         declarator: (reference_declarator (identifier))
         right: (initializer_list (number_literal) (number_literal) (number_literal))
         body: (compound_statement
@@ -319,7 +319,7 @@ void f() {
               (case_statement (number_literal) (compound_statement))))))
       (attributed_statement (attribute_declaration (attribute (identifier))) (while_statement (condition_clause (true)) (compound_statement)))
       (attributed_statement (attribute_declaration (attribute (identifier))) (if_statement (condition_clause (true)) (compound_statement)))
-      (attributed_statement (attribute_declaration (attribute (identifier))) (for_range_loop (auto) (identifier) (identifier) (compound_statement)))
+      (attributed_statement (attribute_declaration (attribute (identifier))) (for_range_loop (placeholder_type_specifier (auto)) (identifier) (identifier) (compound_statement)))
       (attributed_statement (attribute_declaration (attribute (identifier))) (for_statement (compound_statement)))
       (attributed_statement (attribute_declaration (attribute (identifier))) (return_statement))
       (attributed_statement (attribute_declaration (attribute (identifier))) (expression_statement (identifier)))
@@ -373,7 +373,7 @@ void foo(int a) {
     (compound_statement
       (switch_statement (condition_clause (identifier))
         (compound_statement
-          (case_statement (number_literal) (for_range_loop (auto) (identifier) (identifier) (compound_statement)))
+          (case_statement (number_literal) (for_range_loop (placeholder_type_specifier (auto)) (identifier) (identifier) (compound_statement)))
           (case_statement (number_literal) (try_statement (compound_statement (comment)) (catch_clause (parameter_list) (compound_statement))) (throw_statement (number_literal)))
           (case_statement (number_literal) (co_return_statement))
           (case_statement (co_yield_statement (identifier))))))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -13,7 +13,7 @@ void foo() {
     (primitive_type)
     (function_declarator (identifier) (parameter_list))
     (compound_statement
-      (declaration (auto) (init_declarator (identifier) (number_literal))))))
+      (declaration (placeholder_type_specifier (auto)) (init_declarator (identifier) (number_literal))))))
 
 ==========================================
 Namespaced types
@@ -130,7 +130,7 @@ template<typename T, typename U> auto add(T t, U u) -> decltype(t + u);
     (template_parameter_list
       (type_parameter_declaration (type_identifier)) (type_parameter_declaration (type_identifier)))
     (declaration
-      (auto)
+      (placeholder_type_specifier (auto))
       (function_declarator
         (identifier)
         (parameter_list
@@ -149,7 +149,7 @@ auto a::foo() const -> const A<B>& {}
 
 (translation_unit
   (function_definition
-    (auto)
+    (placeholder_type_specifier (auto))
     (function_declarator
       (qualified_identifier (namespace_identifier) (identifier))
       (parameter_list)


### PR DESCRIPTION
@theHamsta this adds support for one of the two remaining things for concepts.

The function declarator one is a bit heavier since it requires a _lot_ more parse states and grows the parser pretty substantially, so I want to play with it a bit more first.