### PR TITLE
Implement fold expressions and more complete requires clauses

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -314,8 +314,8 @@ module.exports = grammar(C, {
               )),
               // It is technically legal to skip the comma here, but that means there is a hard conflict between
               // a variadic template type pack expansion parameter that is unnamed, and a normal type parameter
-              // that is unnamed followed by the ellipsis for a variadic function. Since skipping the comma is for
-              // compatability with pre standard code
+              // that is unnamed followed by the ellipsis for a variadic function. Since allowing no the comma is
+              // for compatability with pre standard code, hopefully its ok to not support it in this grammar.
               //
               // eg:
               //  This is a template function declaration with unnamed parameters declared through pack expansion

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4338,87 +4338,60 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "parameter_declaration"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "optional_parameter_declaration"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "variadic_parameter_declaration"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": ","
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "parameter_declaration"
-                                  },
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "optional_parameter_declaration"
-                                  },
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "variadic_parameter_declaration"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
+                      "type": "SYMBOL",
+                      "name": "parameter_declaration"
                     },
                     {
-                      "type": "BLANK"
+                      "type": "SYMBOL",
+                      "name": "optional_parameter_declaration"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "variadic_parameter_declaration"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "..."
                     }
                   ]
                 },
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "..."
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "parameter_declaration"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "optional_parameter_declaration"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "variadic_parameter_declaration"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "..."
+                          }
+                        ]
+                      }
+                    ]
+                  }
                 }
               ]
             },
             {
-              "type": "STRING",
-              "value": "..."
+              "type": "BLANK"
             }
           ]
         },
@@ -10382,7 +10355,7 @@
         }
       ]
     },
-    "requirement_conjunction": {
+    "constraint_conjunction": {
       "type": "PREC_LEFT",
       "value": 2,
       "content": {
@@ -10415,7 +10388,7 @@
         ]
       }
     },
-    "requirement_disjunction": {
+    "constraint_disjunction": {
       "type": "PREC_LEFT",
       "value": 1,
       "content": {
@@ -10494,11 +10467,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "requirement_conjunction"
+          "name": "constraint_conjunction"
         },
         {
           "type": "SYMBOL",
-          "name": "requirement_disjunction"
+          "name": "constraint_disjunction"
         }
       ]
     },
@@ -10953,8 +10926,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "+"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "+"
+              }
             },
             {
               "type": "STRING",
@@ -10970,8 +10947,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "-"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "-"
+              }
             },
             {
               "type": "STRING",
@@ -10987,8 +10968,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "*"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "*"
+              }
             },
             {
               "type": "STRING",
@@ -11004,8 +10989,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "/"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "/"
+              }
             },
             {
               "type": "STRING",
@@ -11021,8 +11010,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "%"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "%"
+              }
             },
             {
               "type": "STRING",
@@ -11038,8 +11031,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "^"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "^"
+              }
             },
             {
               "type": "STRING",
@@ -11055,8 +11052,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "&"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "&"
+              }
             },
             {
               "type": "STRING",
@@ -11072,8 +11073,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "|"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "|"
+              }
             },
             {
               "type": "STRING",
@@ -11089,8 +11094,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "="
+              }
             },
             {
               "type": "STRING",
@@ -11106,8 +11115,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "<"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "<"
+              }
             },
             {
               "type": "STRING",
@@ -11123,8 +11136,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": ">"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": ">"
+              }
             },
             {
               "type": "STRING",
@@ -11140,8 +11157,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "<<"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "<<"
+              }
             },
             {
               "type": "STRING",
@@ -11157,8 +11178,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": ">>"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": ">>"
+              }
             },
             {
               "type": "STRING",
@@ -11174,8 +11199,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "+="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "+="
+              }
             },
             {
               "type": "STRING",
@@ -11191,8 +11220,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "-="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "-="
+              }
             },
             {
               "type": "STRING",
@@ -11208,8 +11241,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "*="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "*="
+              }
             },
             {
               "type": "STRING",
@@ -11225,8 +11262,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "/="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "/="
+              }
             },
             {
               "type": "STRING",
@@ -11242,8 +11283,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "%="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "%="
+              }
             },
             {
               "type": "STRING",
@@ -11259,8 +11304,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "^="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "^="
+              }
             },
             {
               "type": "STRING",
@@ -11276,8 +11325,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "&="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "&="
+              }
             },
             {
               "type": "STRING",
@@ -11293,8 +11346,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "|="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "|="
+              }
             },
             {
               "type": "STRING",
@@ -11310,8 +11367,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": ">>="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": ">>="
+              }
             },
             {
               "type": "STRING",
@@ -11327,8 +11388,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "<<="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "<<="
+              }
             },
             {
               "type": "STRING",
@@ -11344,8 +11409,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "=="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "=="
+              }
             },
             {
               "type": "STRING",
@@ -11361,8 +11430,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "!="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "!="
+              }
             },
             {
               "type": "STRING",
@@ -11378,8 +11451,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "<="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "<="
+              }
             },
             {
               "type": "STRING",
@@ -11395,8 +11472,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": ">="
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": ">="
+              }
             },
             {
               "type": "STRING",
@@ -11412,8 +11493,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "&&"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "&&"
+              }
             },
             {
               "type": "STRING",
@@ -11429,8 +11514,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "||"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "||"
+              }
             },
             {
               "type": "STRING",
@@ -11446,8 +11535,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": ","
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": ","
+              }
             },
             {
               "type": "STRING",
@@ -11463,8 +11556,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": ".*"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": ".*"
+              }
             },
             {
               "type": "STRING",
@@ -11480,8 +11577,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "->*"
+              "type": "FIELD",
+              "name": "operator",
+              "content": {
+                "type": "STRING",
+                "value": "->*"
+              }
             },
             {
               "type": "STRING",
@@ -11492,23 +11593,6 @@
               "value": "->*"
             }
           ]
-        }
-      ]
-    },
-    "_unary_right_fold": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "..."
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_fold_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
         }
       ]
     },
@@ -11516,16 +11600,57 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "FIELD",
+          "name": "left",
+          "content": {
+            "type": "STRING",
+            "value": "..."
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "_fold_operator"
+          "type": "FIELD",
+          "name": "operator",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_fold_operator"
+          }
         },
         {
-          "type": "STRING",
-          "value": "..."
+          "type": "FIELD",
+          "name": "right",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        }
+      ]
+    },
+    "_unary_right_fold": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "left",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "operator",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_fold_operator"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "right",
+          "content": {
+            "type": "STRING",
+            "value": "..."
+          }
         }
       ]
     },
@@ -11533,16 +11658,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "FIELD",
+          "name": "left",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
         },
         {
           "type": "SYMBOL",
           "name": "_binary_fold_operator"
         },
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "FIELD",
+          "name": "right",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4338,60 +4338,87 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "parameter_declaration"
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "parameter_declaration"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "optional_parameter_declaration"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "variadic_parameter_declaration"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "parameter_declaration"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "optional_parameter_declaration"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "variadic_parameter_declaration"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "optional_parameter_declaration"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "variadic_parameter_declaration"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "..."
+                      "type": "BLANK"
                     }
                   ]
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "parameter_declaration"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "optional_parameter_declaration"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "variadic_parameter_declaration"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "..."
-                          }
-                        ]
-                      }
-                    ]
-                  }
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "..."
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
             {
-              "type": "BLANK"
+              "type": "STRING",
+              "value": "..."
             }
           ]
         },
@@ -5190,6 +5217,10 @@
         {
           "type": "SYMBOL",
           "name": "user_defined_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fold_expression"
         }
       ]
     },
@@ -10351,6 +10382,126 @@
         }
       ]
     },
+    "requirement_conjunction": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_requirement_clause_constraint"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "&&"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_requirement_clause_constraint"
+            }
+          }
+        ]
+      }
+    },
+    "requirement_disjunction": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_requirement_clause_constraint"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "||"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_requirement_clause_constraint"
+            }
+          }
+        ]
+      }
+    },
+    "_requirement_clause_constraint": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "true"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "false"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_class_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fold_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lambda_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "requires_expression"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "requirement_conjunction"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "requirement_disjunction"
+        }
+      ]
+    },
     "requires_clause": {
       "type": "SEQ",
       "members": [
@@ -10362,18 +10513,81 @@
           "type": "FIELD",
           "name": "constraint",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_class_name"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "requires_expression"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_requirement_clause_constraint"
           }
+        }
+      ]
+    },
+    "requires_parameter_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "parameter_declaration"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "optional_parameter_declaration"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "variadic_parameter_declaration"
+                    }
+                  ]
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "parameter_declaration"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "optional_parameter_declaration"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "variadic_parameter_declaration"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },
@@ -10391,8 +10605,13 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "parameter_list"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "requires_parameter_list"
+                },
+                "named": true,
+                "value": "parameter_list"
               },
               {
                 "type": "BLANK"
@@ -10591,6 +10810,769 @@
         {
           "type": "STRING",
           "value": "&"
+        }
+      ]
+    },
+    "_fold_operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "+"
+        },
+        {
+          "type": "STRING",
+          "value": "-"
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "STRING",
+          "value": "/"
+        },
+        {
+          "type": "STRING",
+          "value": "%"
+        },
+        {
+          "type": "STRING",
+          "value": "^"
+        },
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": "<<"
+        },
+        {
+          "type": "STRING",
+          "value": ">>"
+        },
+        {
+          "type": "STRING",
+          "value": "+="
+        },
+        {
+          "type": "STRING",
+          "value": "-="
+        },
+        {
+          "type": "STRING",
+          "value": "*="
+        },
+        {
+          "type": "STRING",
+          "value": "/="
+        },
+        {
+          "type": "STRING",
+          "value": "%="
+        },
+        {
+          "type": "STRING",
+          "value": "^="
+        },
+        {
+          "type": "STRING",
+          "value": "&="
+        },
+        {
+          "type": "STRING",
+          "value": "|="
+        },
+        {
+          "type": "STRING",
+          "value": ">>="
+        },
+        {
+          "type": "STRING",
+          "value": "<<="
+        },
+        {
+          "type": "STRING",
+          "value": "=="
+        },
+        {
+          "type": "STRING",
+          "value": "!="
+        },
+        {
+          "type": "STRING",
+          "value": "<="
+        },
+        {
+          "type": "STRING",
+          "value": ">="
+        },
+        {
+          "type": "STRING",
+          "value": "&&"
+        },
+        {
+          "type": "STRING",
+          "value": "||"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "STRING",
+          "value": ".*"
+        },
+        {
+          "type": "STRING",
+          "value": "->*"
+        }
+      ]
+    },
+    "_binary_fold_operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "+"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "+"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "-"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "-"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "*"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "/"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "/"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "%"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "%"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "^"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "^"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "&"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "&"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "|"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "|"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "<"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ">"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": ">"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<<"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "<<"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ">>"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": ">>"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "+="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "+="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "-="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "-="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "*="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "*="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "/="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "/="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "%="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "%="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "^="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "^="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "&="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "&="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "|="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "|="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ">>="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": ">>="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<<="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "<<="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "=="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "!="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "!="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "<="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ">="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": ">="
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "&&"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "&&"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "||"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "||"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": ","
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ".*"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": ".*"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "->*"
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": "->*"
+            }
+          ]
+        }
+      ]
+    },
+    "_unary_right_fold": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "..."
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_fold_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        }
+      ]
+    },
+    "_unary_left_fold": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_fold_operator"
+        },
+        {
+          "type": "STRING",
+          "value": "..."
+        }
+      ]
+    },
+    "_binary_fold": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_binary_fold_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        }
+      ]
+    },
+    "fold_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_unary_right_fold"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_unary_left_fold"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_binary_fold"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },
@@ -11302,6 +12284,10 @@
       "operator_cast_declaration",
       "operator_cast_definition",
       "constructor_or_destructor_definition"
+    ],
+    [
+      "_binary_fold_operator",
+      "_fold_operator"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1667,6 +1667,174 @@
     }
   },
   {
+    "type": "constraint_conjunction",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "constraint_conjunction",
+            "named": true
+          },
+          {
+            "type": "constraint_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "&&",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "constraint_conjunction",
+            "named": true
+          },
+          {
+            "type": "constraint_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "constraint_disjunction",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "constraint_conjunction",
+            "named": true
+          },
+          {
+            "type": "constraint_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "||",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "constraint_conjunction",
+            "named": true
+          },
+          {
+            "type": "constraint_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "continue_statement",
     "named": true,
     "fields": {}
@@ -2369,16 +2537,169 @@
   {
     "type": "fold_expression",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "...",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "!=",
+            "named": false
+          },
+          {
+            "type": "%",
+            "named": false
+          },
+          {
+            "type": "%=",
+            "named": false
+          },
+          {
+            "type": "&",
+            "named": false
+          },
+          {
+            "type": "&&",
+            "named": false
+          },
+          {
+            "type": "&=",
+            "named": false
+          },
+          {
+            "type": "*",
+            "named": false
+          },
+          {
+            "type": "*=",
+            "named": false
+          },
+          {
+            "type": "+",
+            "named": false
+          },
+          {
+            "type": "+=",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "-",
+            "named": false
+          },
+          {
+            "type": "-=",
+            "named": false
+          },
+          {
+            "type": "->*",
+            "named": false
+          },
+          {
+            "type": ".*",
+            "named": false
+          },
+          {
+            "type": "/",
+            "named": false
+          },
+          {
+            "type": "/=",
+            "named": false
+          },
+          {
+            "type": "<",
+            "named": false
+          },
+          {
+            "type": "<<",
+            "named": false
+          },
+          {
+            "type": "<<=",
+            "named": false
+          },
+          {
+            "type": "<=",
+            "named": false
+          },
+          {
+            "type": "=",
+            "named": false
+          },
+          {
+            "type": "==",
+            "named": false
+          },
+          {
+            "type": ">",
+            "named": false
+          },
+          {
+            "type": ">=",
+            "named": false
+          },
+          {
+            "type": ">>",
+            "named": false
+          },
+          {
+            "type": ">>=",
+            "named": false
+          },
+          {
+            "type": "^",
+            "named": false
+          },
+          {
+            "type": "^=",
+            "named": false
+          },
+          {
+            "type": "|",
+            "named": false
+          },
+          {
+            "type": "|=",
+            "named": false
+          },
+          {
+            "type": "||",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "...",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4458,174 +4779,6 @@
     }
   },
   {
-    "type": "requirement_conjunction",
-    "named": true,
-    "fields": {
-      "left": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "requirement_conjunction",
-            "named": true
-          },
-          {
-            "type": "requirement_disjunction",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          },
-          {
-            "type": "type_identifier",
-            "named": true
-          }
-        ]
-      },
-      "operator": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "&&",
-            "named": false
-          }
-        ]
-      },
-      "right": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "requirement_conjunction",
-            "named": true
-          },
-          {
-            "type": "requirement_disjunction",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          },
-          {
-            "type": "type_identifier",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "requirement_disjunction",
-    "named": true,
-    "fields": {
-      "left": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "requirement_conjunction",
-            "named": true
-          },
-          {
-            "type": "requirement_disjunction",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          },
-          {
-            "type": "type_identifier",
-            "named": true
-          }
-        ]
-      },
-      "operator": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "||",
-            "named": false
-          }
-        ]
-      },
-      "right": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "requirement_conjunction",
-            "named": true
-          },
-          {
-            "type": "requirement_disjunction",
-            "named": true
-          },
-          {
-            "type": "template_type",
-            "named": true
-          },
-          {
-            "type": "type_identifier",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
     "type": "requirement_seq",
     "named": true,
     "fields": {},
@@ -4669,11 +4822,11 @@
             "named": true
           },
           {
-            "type": "requirement_conjunction",
+            "type": "constraint_conjunction",
             "named": true
           },
           {
-            "type": "requirement_disjunction",
+            "type": "constraint_disjunction",
             "named": true
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -132,6 +132,10 @@
         "named": true
       },
       {
+        "type": "fold_expression",
+        "named": true
+      },
+      {
         "type": "identifier",
         "named": true
       },
@@ -2363,6 +2367,21 @@
     }
   },
   {
+    "type": "fold_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "for_range_loop",
     "named": true,
     "fields": {
@@ -4439,6 +4458,174 @@
     }
   },
   {
+    "type": "requirement_conjunction",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "requirement_conjunction",
+            "named": true
+          },
+          {
+            "type": "requirement_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "&&",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "requirement_conjunction",
+            "named": true
+          },
+          {
+            "type": "requirement_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "requirement_disjunction",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "requirement_conjunction",
+            "named": true
+          },
+          {
+            "type": "requirement_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "||",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "requirement_conjunction",
+            "named": true
+          },
+          {
+            "type": "requirement_disjunction",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "requirement_seq",
     "named": true,
     "fields": {},
@@ -4466,15 +4653,27 @@
     "named": true,
     "fields": {
       "constraint": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
-            "type": "qualified_identifier",
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "_expression",
             "named": true
           },
           {
-            "type": "requires_expression",
+            "type": "requirement_conjunction",
+            "named": true
+          },
+          {
+            "type": "requirement_disjunction",
             "named": true
           },
           {
@@ -5806,6 +6005,10 @@
   },
   {
     "type": ".",
+    "named": false
+  },
+  {
+    "type": ".*",
     "named": false
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*

--- a/test/corpus/concepts.txt
+++ b/test/corpus/concepts.txt
@@ -91,6 +91,22 @@ template<typename T>
     requires requires (T x) { x + x; } // ad-hoc constraint, note keyword used twice
 T add(T a, T b) { return a + b; }
 
+template<typename T>
+    requires (!std::is_same_v<T, bool>) // parenthesized expressions are allowed
+void f(T);
+
+template<typename T> requires Addable<T> && Subtractable<T> // conjunctions
+T f(T);
+
+template<typename T> requires Addable<T> || Subtractable<T> // disjunctions
+T f(T);
+
+template<typename T> requires false || true // boolean literals
+T f(T);
+
+template<typename... T> requires (... && Addable<T>) // fold expressions
+T f(T);
+
 --------------------------------------------------------------------------------
 
 (translation_unit
@@ -188,7 +204,113 @@ T add(T a, T b) { return a + b; }
         (return_statement
           (binary_expression
             (identifier)
-            (identifier)))))))
+            (identifier))))))
+      (template_declaration
+        (template_parameter_list
+          (type_parameter_declaration
+            (type_identifier)))
+        (requires_clause
+          (unary_expression
+            (qualified_identifier
+              (namespace_identifier)
+              (template_function
+                (identifier)
+                (template_argument_list
+                  (type_descriptor
+                    (type_identifier))
+                  (type_descriptor
+                    (primitive_type)))))))
+        (comment)
+        (declaration
+          (primitive_type)
+          (function_declarator
+            (identifier)
+            (parameter_list
+              (parameter_declaration
+                (type_identifier))))))
+      (template_declaration
+        (template_parameter_list
+          (type_parameter_declaration
+            (type_identifier)))
+        (requires_clause
+          (requirement_conjunction
+            (template_type
+              (type_identifier)
+              (template_argument_list
+                (type_descriptor
+                  (type_identifier))))
+            (template_type
+              (type_identifier)
+              (template_argument_list
+                (type_descriptor
+                  (type_identifier))))))
+        (comment)
+        (declaration
+          (type_identifier)
+          (function_declarator
+            (identifier)
+            (parameter_list
+              (parameter_declaration
+                (type_identifier))))))
+      (template_declaration
+        (template_parameter_list
+          (type_parameter_declaration
+            (type_identifier)))
+        (requires_clause
+          (requirement_disjunction
+            (template_type
+              (type_identifier)
+              (template_argument_list
+                (type_descriptor
+                  (type_identifier))))
+            (template_type
+              (type_identifier)
+              (template_argument_list
+                (type_descriptor
+                  (type_identifier))))))
+        (comment)
+        (declaration
+          (type_identifier)
+          (function_declarator
+            (identifier)
+            (parameter_list
+              (parameter_declaration
+                (type_identifier))))))
+      (template_declaration
+        (template_parameter_list
+          (type_parameter_declaration
+            (type_identifier)))
+        (requires_clause
+          (requirement_disjunction
+            (false)
+            (true)))
+        (comment)
+        (declaration
+          (type_identifier)
+          (function_declarator
+            (identifier)
+            (parameter_list
+              (parameter_declaration
+                (type_identifier))))))
+      (template_declaration
+        (template_parameter_list
+          (variadic_type_parameter_declaration
+            (type_identifier)))
+        (requires_clause
+          (fold_expression
+            (template_function
+              (identifier)
+              (template_argument_list
+                (type_descriptor
+                  (type_identifier))))))
+        (comment)
+        (declaration
+          (type_identifier)
+          (function_declarator
+            (identifier)
+            (parameter_list
+              (parameter_declaration
+                (type_identifier)))))))
 
 ================================================================================
 Compound requirements

--- a/test/corpus/concepts.txt
+++ b/test/corpus/concepts.txt
@@ -233,7 +233,7 @@ T f(T);
           (type_parameter_declaration
             (type_identifier)))
         (requires_clause
-          (requirement_conjunction
+          (constraint_conjunction
             (template_type
               (type_identifier)
               (template_argument_list
@@ -257,7 +257,7 @@ T f(T);
           (type_parameter_declaration
             (type_identifier)))
         (requires_clause
-          (requirement_disjunction
+          (constraint_disjunction
             (template_type
               (type_identifier)
               (template_argument_list
@@ -281,7 +281,7 @@ T f(T);
           (type_parameter_declaration
             (type_identifier)))
         (requires_clause
-          (requirement_disjunction
+          (constraint_disjunction
             (false)
             (true)))
         (comment)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -908,7 +908,7 @@ co_await fn() || co_await var;
         (identifier)))))
 
 ============================================
- Three-way comparison
+Three-way comparison
 ============================================
 
 auto x = a <=> b;
@@ -934,3 +934,58 @@ bool y = 0 > a <=> b;
         (binary_expression
           (identifier)
           (identifier))))))
+
+============================================
+Fold Expressions
+============================================
+
+bool t  = (... + IndexOf<T>);
+bool t2 = (IndexOf<T> + ...);
+bool t3 = (1 + ... + IndexOf<T>);
+bool t3 = (IndexOf<T> + ... + 1);
+
+---
+
+(translation_unit
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (fold_expression
+        (template_function
+          (identifier)
+          (template_argument_list
+            (type_descriptor
+              (type_identifier)))))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (fold_expression
+        (template_function
+          (identifier)
+          (template_argument_list
+            (type_descriptor
+              (type_identifier)))))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (fold_expression
+        (number_literal)
+        (template_function
+          (identifier)
+          (template_argument_list
+            (type_descriptor
+              (type_identifier)))))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (fold_expression
+        (template_function
+          (identifier)
+          (template_argument_list
+            (type_descriptor
+              (type_identifier))))
+        (number_literal)))))


### PR DESCRIPTION
Fold Expressions
==========
This PR adds rules to recognize fold expressions.

Example:
```cpp
int t = (... + IndexOf<T>);
```
currently produces an error because the ellipsis is unrecognized:
```
(translation_unit [0, 0] - [0, 27]
  (declaration [0, 0] - [0, 27]
    type: (primitive_type [0, 0] - [0, 3])
    declarator: (init_declarator [0, 4] - [0, 26]
      declarator: (identifier [0, 4] - [0, 5])
      value: (parenthesized_expression [0, 8] - [0, 26]
        (ERROR [0, 9] - [0, 12])
        (unary_expression [0, 13] - [0, 25]
          argument: (template_function [0, 15] - [0, 25]
            name: (identifier [0, 15] - [0, 22])
            arguments: (template_argument_list [0, 22] - [0, 25]
              (type_descriptor [0, 23] - [0, 24]
                type: (type_identifier [0, 23] - [0, 24])))))))))
```

but with this PR, the ellipsis is recognized and produces a `fold_expression` node:
```
(translation_unit [0, 0] - [0, 27]
  (declaration [0, 0] - [0, 27]
    type: (primitive_type [0, 0] - [0, 3])
    declarator: (init_declarator [0, 4] - [0, 26]
      declarator: (identifier [0, 4] - [0, 5])
      value: (fold_expression [0, 8] - [0, 26]
        (template_function [0, 15] - [0, 25]
          name: (identifier [0, 15] - [0, 22])
          arguments: (template_argument_list [0, 22] - [0, 25]
            (type_descriptor [0, 23] - [0, 24]
              type: (type_identifier [0, 23] - [0, 24]))))))))
```

The other three types of fold expressions are improved in similar ways:
```cpp
int t = (IndexOf<T> + ...);
int t = (1 + ... + IndexOf<T>);
int t = (IndexOf<T> + ... + 1);
```

Requires Clauses
==========
The current support for a requires clause only works for a single template/concept name or a requires expression, but does not support boolean expressions, or other expressions as outlined on [cppreference.com](https://en.cppreference.com/w/cpp/language/constraints):

- a [primary expression](https://en.cppreference.com/w/cpp/language/expressions#Primary_expressions), e.g. Swappable<T>, [std::is_integral](http://en.cppreference.com/w/cpp/types/is_integral)<T>::value, ([std::is_object_v](http://en.cppreference.com/w/cpp/types/is_object)<Args> && ...), or any parenthesized expression
- a sequence of primary expressions joined with the operator &&
- a sequence of aforementioned expressions joined with the operator ||

where a primary expression is defined as (again from [cppreference.com](https://en.cppreference.com/w/cpp/language/expressions#Primary_expressions)):
- Literals (e.g. 2 or "Hello, world")
- Id-expressions, including
        suitably declared [unqualified identifiers](https://en.cppreference.com/w/cpp/language/identifiers#Unqualified_identifiers) (e.g. n or cout), and
        suitably declared [qualified identifiers](https://en.cppreference.com/w/cpp/language/identifiers#Qualified_identifiers) (e.g. [std::string::npos](https://en.cppreference.com/w/cpp/string/basic_string/npos)) 
- [Lambda-expressions](https://en.cppreference.com/w/cpp/language/lambda) (since C++11)
- [Fold-expressions](https://en.cppreference.com/w/cpp/language/fold) (since C++17)
- [Requires-expressions](https://en.cppreference.com/w/cpp/language/constraints) (since C++20)

I'm not sure if some of these things have much use in a requires clause (what does `requires "Hello, world"` mean?), but this PR upgrades the grammar to accept lambda expressions, fold expressions, any parenthesized expression, boolean literals, and conjunctions/disjunctions.

Example:
```cpp
template<typename T> requires (!std::is_same_v<T, bool>) T f2(T);
```
currently produces errors from the parentheses and negation part of the expression:
```
(translation_unit [0, 0] - [0, 64]
  (template_declaration [0, 0] - [0, 64]
    parameters: (template_parameter_list [0, 8] - [0, 20]
      (type_parameter_declaration [0, 9] - [0, 19]
        (type_identifier [0, 18] - [0, 19])))
    (requires_clause [0, 21] - [0, 54]
      (ERROR [0, 29] - [0, 31])
      constraint: (qualified_identifier [0, 31] - [0, 54]
        scope: (namespace_identifier [0, 31] - [0, 34])
        name: (template_type [0, 36] - [0, 54]
          name: (type_identifier [0, 36] - [0, 45])
          arguments: (template_argument_list [0, 45] - [0, 54]
            (identifier [0, 46] - [0, 47])
            (type_descriptor [0, 49] - [0, 53]
              type: (primitive_type [0, 49] - [0, 53]))))))
    (ERROR [0, 54] - [0, 55])
    (declaration [0, 56] - [0, 64]
      type: (type_identifier [0, 56] - [0, 57])
      declarator: (function_declarator [0, 58] - [0, 63]
        declarator: (identifier [0, 58] - [0, 60])
        parameters: (parameter_list [0, 60] - [0, 63]
          (parameter_declaration [0, 61] - [0, 62]
            type: (type_identifier [0, 61] - [0, 62])))))))
```

but with this PR, everything is recognized nicely:
```
(translation_unit [0, 0] - [0, 64]
  (template_declaration [0, 0] - [0, 64]
    parameters: (template_parameter_list [0, 8] - [0, 20]
      (type_parameter_declaration [0, 9] - [0, 19]
        (type_identifier [0, 18] - [0, 19])))
    (requires_clause [0, 21] - [0, 55]
      constraint: (unary_expression [0, 30] - [0, 54]
        argument: (qualified_identifier [0, 31] - [0, 54]
          scope: (namespace_identifier [0, 31] - [0, 34])
          name: (template_function [0, 36] - [0, 54]
            name: (identifier [0, 36] - [0, 45])
            arguments: (template_argument_list [0, 45] - [0, 54]
              (type_descriptor [0, 46] - [0, 47]
                type: (type_identifier [0, 46] - [0, 47]))
              (type_descriptor [0, 49] - [0, 53]
                type: (primitive_type [0, 49] - [0, 53])))))))
    (declaration [0, 56] - [0, 64]
      type: (type_identifier [0, 56] - [0, 57])
      declarator: (function_declarator [0, 58] - [0, 63]
        declarator: (identifier [0, 58] - [0, 60])
        parameters: (parameter_list [0, 60] - [0, 63]
          (parameter_declaration [0, 61] - [0, 62]
            type: (type_identifier [0, 61] - [0, 62])))))))
```

Tests for both fold expressions and the newly supported pieces of require clauses have been added.