### PR TITLE
Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 build
 package-lock.json
 /target/
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterCPP",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterCPP", targets: ["TreeSitterCPP"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterCPP",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "examples",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterCPP/cpp.h
+++ b/bindings/swift/TreeSitterCPP/cpp.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_CPP_H_
+#define TREE_SITTER_CPP_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_cpp();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_CPP_H_


### PR DESCRIPTION
Swift's package manager can build C/C++ sources and use headers to expose functions to Swift. The standard tree-sitter parser project layout just requires a little extra configuration to make it happy.

Grammars with SPM support to this date:
- https://github.com/tree-sitter/tree-sitter-javascript
- https://github.com/tree-sitter/tree-sitter-php
- https://github.com/tree-sitter/tree-sitter-c
- https://github.com/tree-sitter/tree-sitter-java
- https://github.com/tree-sitter/tree-sitter-rust
