### PR TITLE
Add support for alternative operators 'and, or, not' (#94)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -805,6 +805,8 @@ module.exports = grammar(C, {
       $.this,
       $.raw_string_literal,
       $.user_defined_literal,
+      $.alternative_unary,
+      $.alternative_binary,
       $.fold_expression
     ),
 
@@ -1133,6 +1135,25 @@ module.exports = grammar(C, {
       ),
       $.literal_suffix
     ),
+
+    alternative_unary: $ => prec.left(PREC.UNARY, seq(
+      field('operator', choice('not')),
+      field('argument', $._expression)
+    )),
+
+    alternative_binary: $ => {
+      const table = [
+        ['or',  PREC.LOGICAL_OR],
+        ['and', PREC.LOGICAL_AND],
+      ];
+      return choice(...table.map(([operator, precedence]) => {
+        return prec.left(precedence, seq(
+          field('left', $._expression),
+          field('operator', operator),
+          field('right', $._expression)
+        ))
+      }));
+    },
 
     _namespace_identifier: $ => alias($.identifier, $.namespace_identifier)
   }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -72,3 +72,11 @@
 ; Strings
 
 (raw_string_literal) @string
+
+; Operators
+
+[
+ "and"
+ "or"
+ "not"
+] @operator

--- a/test/corpus/alternatives.txt
+++ b/test/corpus/alternatives.txt
@@ -1,0 +1,21 @@
+==============================================================
+Alternative tokens and or not
+==============================================================
+
+if (not marked and (x < left or right < x)) {
+
+}
+
+---
+
+(translation_unit
+  (if_statement
+    (condition_clause
+      (alternative_binary
+        (alternative_unary (identifier))
+        (parenthesized_expression
+          (alternative_binary
+            (binary_expression (identifier) (identifier))
+            (binary_expression (identifier) (identifier))))))
+    (compound_statement)))
+


### PR DESCRIPTION
Firstly, thank you for this great plugin.
Sometimes, C++ alternative tokens provide natural readability when used. This update adds support for three frequently used operators (and, or, not), and additional operators may be added later. Thanks,