### PR TITLE
Add support for alternative operators 'and, or, not' (#94)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -805,6 +805,8 @@ module.exports = grammar(C, {
       $.this,
       $.raw_string_literal,
       $.user_defined_literal,
+      $.alternative_unary,
+      $.alternative_binary,
       $.fold_expression
     ),
 
@@ -1133,6 +1135,25 @@ module.exports = grammar(C, {
       ),
       $.literal_suffix
     ),
+
+    alternative_unary: $ => prec.left(PREC.UNARY, seq(
+      field('operator', 'not'),
+      field('argument', $._expression)
+    )),
+
+    alternative_binary: $ => {
+      const table = [
+        ['or',  PREC.LOGICAL_OR],
+        ['and', PREC.LOGICAL_AND],
+      ];
+      return choice(...table.map(([operator, precedence]) => {
+        return prec.left(precedence, seq(
+          field('left', $._expression),
+          field('operator', operator),
+          field('right', $._expression)
+        ))
+      }));
+    },
 
     _namespace_identifier: $ => alias($.identifier, $.namespace_identifier)
   }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -72,3 +72,11 @@
 ; Strings
 
 (raw_string_literal) @string
+
+; Operators
+
+[
+ "and"
+ "or"
+ "not"
+] @operator

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5193,6 +5193,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "alternative_unary"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alternative_binary"
+        },
+        {
+          "type": "SYMBOL",
           "name": "fold_expression"
         }
       ]
@@ -12259,6 +12267,102 @@
         {
           "type": "SYMBOL",
           "name": "literal_suffix"
+        }
+      ]
+    },
+    "alternative_unary": {
+      "type": "PREC_LEFT",
+      "value": 13,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "not"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "argument",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          }
+        ]
+      }
+    },
+    "alternative_binary": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "or"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 2,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "and"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -84,6 +84,14 @@
     "named": true,
     "subtypes": [
       {
+        "type": "alternative_binary",
+        "named": true
+      },
+      {
+        "type": "alternative_unary",
+        "named": true
+      },
+      {
         "type": "assignment_expression",
         "named": true
       },
@@ -607,6 +615,72 @@
           {
             "type": "type_descriptor",
             "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "alternative_binary",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "and",
+            "named": false
+          },
+          {
+            "type": "or",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "alternative_unary",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "not",
+            "named": false
           }
         ]
       }
@@ -6321,6 +6395,10 @@
     "named": false
   },
   {
+    "type": "and",
+    "named": false
+  },
+  {
     "type": "auto",
     "named": true
   },
@@ -6497,6 +6575,10 @@
     "named": false
   },
   {
+    "type": "not",
+    "named": false
+  },
+  {
     "type": "null",
     "named": true
   },
@@ -6510,6 +6592,10 @@
   },
   {
     "type": "operator",
+    "named": false
+  },
+  {
+    "type": "or",
     "named": false
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -989,3 +989,28 @@ bool t3 = (IndexOf<T> + ... + 1);
             (type_descriptor
               (type_identifier))))
         (number_literal)))))
+
+=================================================
+Alternative tokens and or not
+=================================================
+
+if (not marked and (x < left or right < x)) {}
+
+---
+
+(translation_unit
+  (if_statement
+    (condition_clause
+      (alternative_binary
+        (alternative_unary
+          (identifier))
+        (parenthesized_expression
+          (alternative_binary
+            (binary_expression
+              (identifier)
+              (identifier))
+            (binary_expression
+              (identifier)
+              (identifier))))))
+    (compound_statement)))
+


### PR DESCRIPTION
Firstly, thank you for this great plugin.
Sometimes, C++ alternative tokens provide natural readability when used. This update adds support for three frequently used operators (and, or, not), and additional operators may be added later. Thanks,