### PR TITLE
Correct function-try-block parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -417,7 +417,7 @@ module.exports = grammar(C, {
       $._declaration_specifiers,
       field('declarator', $._field_declarator),
       choice(
-        field('body', $.compound_statement),
+        field('body', choice($.compound_statement, $.try_statement)),
         $.default_method_clause,
         $.delete_method_clause
       )
@@ -434,7 +434,7 @@ module.exports = grammar(C, {
         $.operator_cast,
         alias($.qualified_operator_cast_identifier, $.qualified_identifier)
       )),
-      field('body', $.compound_statement)
+      field('body', choice($.compound_statement, $.try_statement))
     ),
 
     operator_cast_declaration: $ => prec(1, seq(
@@ -447,14 +447,22 @@ module.exports = grammar(C, {
       ';'
     )),
 
+    constructor_try_statement: $ => seq(
+      'try',
+      optional($.field_initializer_list),
+      field('body', $.compound_statement),
+      repeat1($.catch_clause)
+    ),
+
     constructor_or_destructor_definition: $ => seq(
       repeat($._constructor_specifiers),
       field('declarator', $.function_declarator),
-      optional($.field_initializer_list),
       choice(
-        field('body', choice(
-          $.compound_statement,
-          $.try_statement)),
+        seq(
+          optional($.field_initializer_list),
+          field('body', $.compound_statement)
+        ),
+        alias($.constructor_try_statement, $.try_statement),
         $.default_method_clause,
         $.delete_method_clause
       )

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4460,6 +4460,22 @@
         }
       ]
     },
+    "attributed_non_case_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_declaration"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_case_statement"
+        }
+      ]
+    },
     "_statement": {
       "type": "CHOICE",
       "members": [
@@ -4479,10 +4495,6 @@
         {
           "type": "CHOICE",
           "members": [
-            {
-              "type": "SYMBOL",
-              "name": "attributed_statement"
-            },
             {
               "type": "SYMBOL",
               "name": "labeled_statement"
@@ -4739,6 +4751,15 @@
               "type": "CHOICE",
               "members": [
                 {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "attributed_non_case_statement"
+                  },
+                  "named": true,
+                  "value": "attributed_statement"
+                },
+                {
                   "type": "SYMBOL",
                   "name": "_non_case_statement"
                 },
@@ -4879,17 +4900,8 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "comma_expression"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "_expression"
               },
               {
                 "type": "BLANK"
@@ -4931,12 +4943,8 @@
           "value": ")"
         },
         {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
-          }
+          "type": "SYMBOL",
+          "name": "_statement"
         }
       ]
     },
@@ -8671,8 +8679,17 @@
               "type": "FIELD",
               "name": "body",
               "content": {
-                "type": "SYMBOL",
-                "name": "compound_statement"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "compound_statement"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "try_statement"
+                  }
+                ]
               }
             },
             {
@@ -8736,8 +8753,17 @@
           "type": "FIELD",
           "name": "body",
           "content": {
-            "type": "SYMBOL",
-            "name": "compound_statement"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "compound_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "try_statement"
+              }
+            ]
           }
         }
       ]
@@ -8809,6 +8835,42 @@
         ]
       }
     },
+    "constructor_try_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "try"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "field_initializer_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "compound_statement"
+          }
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "catch_clause"
+          }
+        }
+      ]
+    },
     "constructor_or_destructor_definition": {
       "type": "SEQ",
       "members": [
@@ -8831,33 +8893,38 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "field_initializer_list"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "body",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "field_initializer_list"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
                     "type": "SYMBOL",
                     "name": "compound_statement"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "try_statement"
                   }
-                ]
-              }
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "constructor_try_statement"
+              },
+              "named": true,
+              "value": "try_statement"
             },
             {
               "type": "SYMBOL",
@@ -12333,11 +12400,12 @@
       "sized_type_specifier"
     ],
     [
+      "_declaration_modifiers",
       "attributed_statement"
     ],
     [
       "_declaration_modifiers",
-      "attributed_statement"
+      "attributed_non_case_statement"
     ],
     [
       "template_function",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -272,10 +272,6 @@
     "named": true,
     "subtypes": [
       {
-        "type": "attributed_statement",
-        "named": true
-      },
-      {
         "type": "break_statement",
         "named": true
       },
@@ -1477,6 +1473,10 @@
           "named": true
         },
         {
+          "type": "attributed_statement",
+          "named": true
+        },
+        {
           "type": "concept_definition",
           "named": true
         },
@@ -1945,6 +1945,10 @@
         },
         {
           "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "attributed_statement",
           "named": true
         },
         {
@@ -2788,26 +2792,12 @@
     "type": "for_statement",
     "named": true,
     "fields": {
-      "body": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_statement",
-            "named": true
-          }
-        ]
-      },
       "condition": {
         "multiple": false,
         "required": false,
         "types": [
           {
             "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "comma_expression",
             "named": true
           }
         ]
@@ -2844,6 +2834,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_statement",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -3034,6 +3034,10 @@
         },
         {
           "type": "storage_class_specifier",
+          "named": true
+        },
+        {
+          "type": "try_statement",
           "named": true
         },
         {
@@ -4153,6 +4157,10 @@
           "named": true
         },
         {
+          "type": "attributed_statement",
+          "named": true
+        },
+        {
           "type": "concept_definition",
           "named": true
         },
@@ -4253,6 +4261,10 @@
         },
         {
           "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "attributed_statement",
           "named": true
         },
         {
@@ -4448,6 +4460,10 @@
           "named": true
         },
         {
+          "type": "attributed_statement",
+          "named": true
+        },
+        {
           "type": "concept_definition",
           "named": true
         },
@@ -4573,6 +4589,10 @@
         },
         {
           "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "attributed_statement",
           "named": true
         },
         {
@@ -5514,6 +5534,10 @@
           "named": true
         },
         {
+          "type": "attributed_statement",
+          "named": true
+        },
+        {
           "type": "concept_definition",
           "named": true
         },
@@ -5605,6 +5629,10 @@
       "types": [
         {
           "type": "catch_clause",
+          "named": true
+        },
+        {
+          "type": "field_initializer_list",
           "named": true
         }
       ]

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -178,7 +178,8 @@ struct S {
   S() : f(0) {}
 
  private:
-  int getF() const { return f; }
+  int getF1() const { return f; }
+  int getF2() const try { throw 1; } catch (...) { return f; }
 };
 
 ---
@@ -194,7 +195,14 @@ struct S {
     (function_definition
       (primitive_type)
       (function_declarator (field_identifier) (parameter_list) (type_qualifier))
-      (compound_statement (return_statement (identifier)))))))
+      (compound_statement (return_statement (identifier))))
+    (function_definition
+      (primitive_type)
+      (function_declarator (field_identifier) (parameter_list) (type_qualifier))
+      (try_statement
+        (compound_statement (throw_statement (number_literal)))
+        (catch_clause (parameter_list)
+          (compound_statement (return_statement (identifier)))))))))
 
 =========================================
 Inline method definitions with overrides

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -34,7 +34,7 @@ T::T() : f1(0), f2(1, 2) {
 
 T::T() : Base<T>() {}
 
-T::T() : f1(0) try {} catch(...) {}
+T::T() try : f1(0) {} catch(...) {}
 
 ---
 
@@ -70,12 +70,12 @@ T::T() : f1(0) try {} catch(...) {}
         (namespace_identifier)
         (identifier))
       (parameter_list))
-    (field_initializer_list
-      (field_initializer
-        (field_identifier)
-        (argument_list
-          (number_literal))))
     (try_statement
+      (field_initializer_list
+        (field_initializer
+          (field_identifier)
+          (argument_list
+            (number_literal))))
       (compound_statement)
       (catch_clause
         (parameter_list)
@@ -194,7 +194,6 @@ T::~T() {}
       (qualified_identifier (namespace_identifier) (destructor_name (identifier))) (parameter_list))
     (compound_statement)))
 
-
 =====================================
 Function-try-block definitions
 =====================================
@@ -214,3 +213,31 @@ void foo() try {} catch(...) {}
       (catch_clause
         (parameter_list)
         (compound_statement)))))
+
+
+=====================================
+Conversion operator definitions
+=====================================
+
+T::operator int() try { throw 1; } catch (...) { return 2; }
+
+---
+
+(translation_unit
+  (function_definition
+    (qualified_identifier
+      (namespace_identifier)
+      (operator_cast
+        (primitive_type)
+        (abstract_function_declarator
+          (parameter_list))))
+    (try_statement
+      (compound_statement
+        (throw_statement
+          (number_literal)))
+      (catch_clause
+        (parameter_list)
+        (compound_statement
+          (return_statement
+            (number_literal)))))))
+


### PR DESCRIPTION
Some time ago I contributed support for function-try-block (#169). I just noticed that the implementation is not correct.

In case of constructor, the initializer list must appear after `try`, like here:
```cpp
    Test() try : member(5) {} catch (...) {}
```
This complicates things a bit because we can not reuse the `try_statement` production.

There were also two other cases where try block is allowed and was missing: in inline member functions and in conversion operators definitions. I extended these two to allow for `try_statement` in body.

Sorry for the mess and thanks in advance for checking this PR!