### PR TITLE
Add support for virtual inheritance

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -206,7 +206,7 @@ module.exports = grammar(C, {
     base_class_clause: $ => seq(
       ':',
       commaSep1(seq(
-        optional(choice('public', 'private', 'protected')),
+        repeat(choice('public', 'private', 'protected', 'virtual')),
         $._class_name,
         optional('...')
       ))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8147,29 +8147,28 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "public"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "private"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "protected"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "public"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "private"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "protected"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "virtual"
+                      }
+                    ]
+                  }
                 },
                 {
                   "type": "SYMBOL",
@@ -8202,29 +8201,28 @@
                     "type": "SEQ",
                     "members": [
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "public"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "private"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "protected"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "public"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "private"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "protected"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "virtual"
+                            }
+                          ]
+                        }
                       },
                       {
                         "type": "SYMBOL",

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -354,6 +354,9 @@ class A : public B {
 class C : C::D, public E {
 };
 
+class F : virtual A, public virtual B, virtual public C {
+};
+
 ---
 
 (translation_unit
@@ -365,6 +368,13 @@ class C : C::D, public E {
     (type_identifier)
     (base_class_clause
       (qualified_identifier (namespace_identifier) (type_identifier))
+      (type_identifier))
+    (field_declaration_list))
+  (class_specifier
+    (type_identifier)
+    (base_class_clause
+      (type_identifier)
+      (type_identifier)
       (type_identifier))
     (field_declaration_list)))
 


### PR DESCRIPTION
This is currently not supported:
```cpp
struct Derived : public virtual Base {};
```

```
struct_specifier [0, 0] - [0, 39]
  name: type_identifier [0, 7] - [0, 14]
  base_class_clause [0, 15] - [0, 31]
    type_identifier [0, 24] - [0, 31]
  ERROR [0, 32] - [0, 36]
    identifier [0, 32] - [0, 36]
  body: field_declaration_list [0, 37] - [0, 39]
```

I did the simplest possible change by adding 'virtual' to access modifiers and allowing to repeat them.

Note that as a side effect the parser now accepts things like `struct S : public private C`. I think that it is acceptable, in a similar way that we allow `void f() noexcept noexcept` or nonsense like `void f() noexcept throw(error)`.
