### PR TITLE
Include rawstring delimiters in the tree, use for injections

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -24,7 +24,8 @@ module.exports = grammar(C, {
   name: 'cpp',
 
   externals: $ => [
-    $.raw_string_literal
+    $.raw_string_delimiter,
+    $.raw_string_content,
   ],
 
   conflicts: ($, original) => original.concat([
@@ -826,6 +827,24 @@ module.exports = grammar(C, {
       $.raw_string_literal,
       $.user_defined_literal,
       $.fold_expression
+    ),
+
+    raw_string_literal: $ => seq(
+      choice('R"', 'LR"', 'uR"', 'UR"', 'u8R"'),
+      choice(
+        seq(
+          field('delimiter', $.raw_string_delimiter),
+          '(',
+          $.raw_string_content,
+          ')',
+          $.raw_string_delimiter,
+        ),
+        seq(
+          '(',
+          $.raw_string_content,
+          ')',
+        )),
+      '"',
     ),
 
     subscript_expression: $ => prec(PREC.SUBSCRIPT, seq(

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
       "highlights": [
         "queries/highlights.scm",
         "node_modules/tree-sitter-c/queries/highlights.scm"
-      ]
+      ],
+      "injections": "queries/injections.scm",
+      "injection-regex": "^(cc|cpp)$"
     }
   ]
 }

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,3 @@
+(raw_string_literal
+  delimiter: (raw_string_delimiter) @injection.language
+  (raw_string_content) @injection.content)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10408,6 +10408,91 @@
         }
       ]
     },
+    "raw_string_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "R\""
+            },
+            {
+              "type": "STRING",
+              "value": "LR\""
+            },
+            {
+              "type": "STRING",
+              "value": "uR\""
+            },
+            {
+              "type": "STRING",
+              "value": "UR\""
+            },
+            {
+              "type": "STRING",
+              "value": "u8R\""
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "delimiter",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "raw_string_delimiter"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "raw_string_content"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "raw_string_delimiter"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "raw_string_content"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "\""
+        }
+      ]
+    },
     "co_await_expression": {
       "type": "PREC_LEFT",
       "value": 13,
@@ -12829,7 +12914,11 @@
   "externals": [
     {
       "type": "SYMBOL",
-      "name": "raw_string_literal"
+      "name": "raw_string_delimiter"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "raw_string_content"
     }
   ],
   "inline": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4812,6 +4812,36 @@
     }
   },
   {
+    "type": "raw_string_literal",
+    "named": true,
+    "fields": {
+      "delimiter": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "raw_string_delimiter",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "raw_string_content",
+          "named": true
+        },
+        {
+          "type": "raw_string_delimiter",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "ref_qualifier",
     "named": true,
     "fields": {}
@@ -6306,11 +6336,23 @@
     "named": false
   },
   {
+    "type": "LR\"",
+    "named": false
+  },
+  {
+    "type": "R\"",
+    "named": false
+  },
+  {
     "type": "U\"",
     "named": false
   },
   {
     "type": "U'",
+    "named": false
+  },
+  {
+    "type": "UR\"",
     "named": false
   },
   {
@@ -6646,7 +6688,11 @@
     "named": false
   },
   {
-    "type": "raw_string_literal",
+    "type": "raw_string_content",
+    "named": true
+  },
+  {
+    "type": "raw_string_delimiter",
     "named": true
   },
   {
@@ -6751,6 +6797,14 @@
   },
   {
     "type": "u8'",
+    "named": false
+  },
+  {
+    "type": "u8R\"",
+    "named": false
+  },
+  {
+    "type": "uR\"",
     "named": false
   },
   {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,5 +1,7 @@
 #include <tree_sitter/parser.h>
 #include <string>
+#include <cassert>
+#include <cstring>
 #include <cwctype>
 
 namespace {
@@ -8,66 +10,64 @@ using std::wstring;
 using std::iswspace;
 
 enum TokenType {
-  RAW_STRING_LITERAL,
+  RAW_STRING_DELIMITER,
+  RAW_STRING_CONTENT,
 };
 
+// The spec limits delimiters to 16 chars, enforce this to bound serialization.
+constexpr unsigned RAW_STRING_DELIMITER_MAX = 16;
+
 struct Scanner {
-  bool scan(TSLexer *lexer, const bool *valid_symbols) {
-    while (iswspace(lexer->lookahead)) {
-      lexer->advance(lexer, true);
-    }
-
-    lexer->result_symbol = RAW_STRING_LITERAL;
-
-    // Raw string literals can start with: R, LR, uR, UR, u8R
-    // Consume 'R'
-    if (lexer->lookahead == 'L' || lexer->lookahead == 'U') {
-      lexer->advance(lexer, false);
-      if (lexer->lookahead != 'R') {
-        return false;
-      }
-    } else if (lexer->lookahead == 'u') {
-      lexer->advance(lexer, false);
-      if (lexer->lookahead == '8') {
-        lexer->advance(lexer, false);
-        if (lexer->lookahead != 'R') {
+  // Last raw_string_delimiter, used to detect when raw_string_content ends.
+  wstring delimiter;
+  
+  // Scan a raw string delimiter in R"delimiter(content)delimiter".
+  bool scan_raw_string_delimiter(TSLexer *lexer) {
+    if (!delimiter.empty()) {
+      // Closing delimiter: must exactly match the opening delimiter.
+      // We already checked this when scanning content, but this is how we know
+      // when to stop. We can't stop at ", because R"""hello""" is valid.
+      for (auto c : delimiter) {
+        if (lexer->lookahead != c)
           return false;
-        }
-      } else if (lexer->lookahead != 'R') {
-        return false;
+        lexer->advance(lexer, false);
       }
-    } else if (lexer->lookahead != 'R') {
-      return false;
+      delimiter.clear();
+      return true;
     }
-    lexer->advance(lexer, false);
-
-    // Consume '"'
-    if (lexer->lookahead != '"') return false;
-    lexer->advance(lexer, false);
-
-    // Consume '(', delimiter
-    wstring delimiter;
+    // Opening delimiter: record the d-char-sequence up to (.
+    // d-char is any basic character except parens, backslashes, and spaces.
     for (;;) {
-      if (lexer->lookahead == 0 || lexer->lookahead == '\\' || iswspace(lexer->lookahead)) {
+      if (delimiter.size() > RAW_STRING_DELIMITER_MAX ||
+          lexer->lookahead == 0 || lexer->lookahead == '\\' || iswspace(lexer->lookahead)) {
         return false;
       }
       if (lexer->lookahead == '(') {
-        lexer->advance(lexer, false);
-        break;
+        // Rather than create a token for an empty delimiter, we fail and let
+        // the grammar fall back to a delimiter-less rule.
+        return !delimiter.empty();
       }
       delimiter += lexer->lookahead;
       lexer->advance(lexer, false);
     }
+  }
 
-    // Consume content, delimiter, ')', '"'
+  // Scan the raw string content in R"delimeter(content)delimiter".
+  bool scan_raw_string_content(TSLexer *lexer) {
+    // The progress made through the delimiter since the last ')'.
+    // The delimiter may not contain ')' so a single counter suffices.
     int delimiter_index = -1;
     for (;;) {
-      if (lexer->lookahead == 0) return false;
+      // If we hit EOF, consider the content to terminate there.
+      // This forms an incomplete raw_string_literal, and models the code well.
+      if (lexer->lookahead == 0) {
+        lexer->mark_end(lexer);
+        return true;
+      }
 
       if (delimiter_index >= 0) {
         if (static_cast<unsigned>(delimiter_index) == delimiter.size()) {
           if (lexer->lookahead == '"') {
-            lexer->advance(lexer, false);
             return true;
           } else {
             delimiter_index = -1;
@@ -82,11 +82,31 @@ struct Scanner {
       }
 
       if (delimiter_index == -1 && lexer->lookahead == ')') {
+        // The content doesn't include the )delimiter" part.
+        // We must still scan through it, but exclude it from the token.
+        lexer->mark_end(lexer);
         delimiter_index = 0;
       }
 
       lexer->advance(lexer, false);
     }
+  }
+  
+
+  bool scan(TSLexer *lexer, const bool *valid_symbols) {
+    // No skipping leading whitespace: raw-string grammar is space-sensitive.
+
+    if (valid_symbols[RAW_STRING_CONTENT]) {
+      lexer->result_symbol = RAW_STRING_CONTENT;
+      return scan_raw_string_content(lexer);
+    }
+      
+    if (valid_symbols[RAW_STRING_DELIMITER]) {
+      lexer->result_symbol = RAW_STRING_DELIMITER;
+      return scan_raw_string_delimiter(lexer);
+    }
+    
+    return false;
   }
 };
 
@@ -105,10 +125,22 @@ bool tree_sitter_cpp_external_scanner_scan(void *payload, TSLexer *lexer,
 }
 
 unsigned tree_sitter_cpp_external_scanner_serialize(void *payload, char *buffer) {
-  return 0;
+  static_assert(
+    RAW_STRING_DELIMITER_MAX * sizeof(wchar_t) < TREE_SITTER_SERIALIZATION_BUFFER_SIZE,
+    "Raw string delimiters may not be serializable!");
+
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  size_t size = scanner->delimiter.size() * sizeof(wchar_t);
+  memcpy(buffer, scanner->delimiter.data(), size);
+  return size;
 }
 
 void tree_sitter_cpp_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+  assert(length % sizeof(wchar_t) == 0 && "Can't decode serialized delimiter!");
+
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  scanner->delimiter.resize(length/sizeof(wchar_t));
+  memcpy(&scanner->delimiter[0], buffer, length);
 }
 
 void tree_sitter_cpp_external_scanner_destroy(void *payload) {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -15,7 +15,7 @@ enum TokenType {
 };
 
 // The spec limits delimiters to 16 chars, enforce this to bound serialization.
-constexpr unsigned RAW_STRING_DELIMITER_MAX = 16;
+const unsigned RAW_STRING_DELIMITER_MAX = 16;
 
 struct Scanner {
   // Last raw_string_delimiter, used to detect when raw_string_content ends.
@@ -27,8 +27,8 @@ struct Scanner {
       // Closing delimiter: must exactly match the opening delimiter.
       // We already checked this when scanning content, but this is how we know
       // when to stop. We can't stop at ", because R"""hello""" is valid.
-      for (auto c : delimiter) {
-        if (lexer->lookahead != c)
+      for (int i = 0; i < delimiter.size(); ++i) {
+        if (lexer->lookahead != delimiter[i])
           return false;
         lexer->advance(lexer, false);
       }
@@ -125,9 +125,11 @@ bool tree_sitter_cpp_external_scanner_scan(void *payload, TSLexer *lexer,
 }
 
 unsigned tree_sitter_cpp_external_scanner_serialize(void *payload, char *buffer) {
-  static_assert(
-    RAW_STRING_DELIMITER_MAX * sizeof(wchar_t) < TREE_SITTER_SERIALIZATION_BUFFER_SIZE,
-    "Raw string delimiters may not be serializable!");
+#if __cpp_static_assert >= 200410L
+  static_assert(RAW_STRING_DELIMITER_MAX * sizeof(wchar_t) <
+                    TREE_SITTER_SERIALIZATION_BUFFER_SIZE,
+                "Raw string delimiters may not be serializable!");
+#endif
 
   Scanner *scanner = static_cast<Scanner *>(payload);
   size_t size = scanner->delimiter.size() * sizeof(wchar_t);

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -52,7 +52,7 @@ struct Scanner {
     }
   }
 
-  // Scan the raw string content in R"delimeter(content)delimiter".
+  // Scan the raw string content in R"delimiter(content)delimiter".
   bool scan_raw_string_content(TSLexer *lexer) {
     // The progress made through the delimiter since the last ')'.
     // The delimiter may not contain ')' so a single counter suffices.

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -27,7 +27,7 @@ struct Scanner {
       // Closing delimiter: must exactly match the opening delimiter.
       // We already checked this when scanning content, but this is how we know
       // when to stop. We can't stop at ", because R"""hello""" is valid.
-      for (int i = 0; i < delimiter.size(); ++i) {
+      for (std::size_t i = 0; i < delimiter.size(); ++i) {
         if (lexer->lookahead != delimiter[i])
           return false;
         lexer->advance(lexer, false);

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1170,7 +1170,7 @@ static_assert(true, R"FOO(string)FOO");
     message: (concatenated_string (string_literal) (string_literal)))
   (static_assert_declaration
     condition: (true)
-    message: (raw_string_literal)))
+    message: (raw_string_literal delimiter: (raw_string_delimiter) (raw_string_content) (raw_string_delimiter))))
 
 =========================================
 Cast operator overload declarations

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -474,37 +474,53 @@ const char *s6 = LR"FOO(
     (primitive_type)
     (init_declarator
       (pointer_declarator (identifier))
-      (raw_string_literal)))
+      (raw_string_literal
+        (raw_string_content))))
   (declaration
     (type_qualifier)
     (primitive_type)
     (init_declarator
       (pointer_declarator (identifier))
-      (raw_string_literal)))
+      (raw_string_literal
+        (raw_string_delimiter)
+        (raw_string_content)
+        (raw_string_delimiter))))
   (declaration
     (type_qualifier)
     (primitive_type)
     (init_declarator
       (pointer_declarator (identifier))
-      (raw_string_literal)))
+      (raw_string_literal
+        (raw_string_delimiter)
+        (raw_string_content)
+        (raw_string_delimiter))))
   (declaration
     (type_qualifier)
     (primitive_type)
     (init_declarator
       (pointer_declarator (identifier))
-      (raw_string_literal)))
+      (raw_string_literal
+        (raw_string_delimiter)
+        (raw_string_content)
+        (raw_string_delimiter))))
   (declaration
     (type_qualifier)
     (primitive_type)
     (init_declarator
       (pointer_declarator (identifier))
-      (raw_string_literal)))
+      (raw_string_literal
+        (raw_string_delimiter)
+        (raw_string_content)
+        (raw_string_delimiter))))
   (declaration
     (type_qualifier)
     (primitive_type)
     (init_declarator
       (pointer_declarator (identifier))
-      (raw_string_literal))))
+      (raw_string_literal
+        (raw_string_delimiter)
+        (raw_string_content)
+        (raw_string_delimiter)))))
 
 ====================================================
 Template calls
@@ -811,8 +827,8 @@ R"(a)" R"(b)" R"(c)";
 
 (translation_unit
   (expression_statement (concatenated_string (string_literal) (string_literal) (string_literal)))
-  (expression_statement (concatenated_string (raw_string_literal) (raw_string_literal) (raw_string_literal)))
-  (expression_statement (concatenated_string (string_literal) (raw_string_literal) (string_literal) (raw_string_literal))))
+  (expression_statement (concatenated_string (raw_string_literal (raw_string_content)) (raw_string_literal (raw_string_content)) (raw_string_literal (raw_string_content))))
+  (expression_statement (concatenated_string (string_literal) (raw_string_literal (raw_string_content)) (string_literal) (raw_string_literal (raw_string_delimiter) (raw_string_content) (raw_string_delimiter)))))
 
 ============================================
 User-defined literals


### PR DESCRIPTION
In raw-strings, the delimiter can be used to indicate embedded language:

```
   R"css( body { background: red; } )css"
```

This patch adds the delimiter (if present) and raw-string content as children of the raw_string_literal.

These can be used to parse the content with an injected grammar.

Fixes https://github.com/tree-sitter/tree-sitter-cpp/issues/159