### PR TITLE
Detect error recovery and don't lex permissive tokens

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -94,6 +94,16 @@ struct Scanner {
   
 
   bool scan(TSLexer *lexer, const bool *valid_symbols) {
+    // After parse error, lexer is called with all valid_symbols true.
+    // There's no other context where both raw content and delimiter are valid.
+    bool error_recovery = valid_symbols[RAW_STRING_CONTENT] &&
+                          valid_symbols[RAW_STRING_DELIMITER];
+
+    // We don't want to recover from an error by e.g. interpreting the rest of
+    // the file as a raw string!
+    // See https://github.com/tree-sitter/tree-sitter/issues/285
+    if (error_recovery) return false;
+
     // No skipping leading whitespace: raw-string grammar is space-sensitive.
 
     if (valid_symbols[RAW_STRING_CONTENT]) {


### PR DESCRIPTION
After cf12e881661e4, the grammar basically stops parsing after hitting an error, lexing the rest of the file as raw_string_content.

The reason is that after a parse error, the lexer gets called with every symbol marked valid, raw_string_content matches anything.

The fix is described in https://github.com/tree-sitter/tree-sitter/issues/285: we detect error-recovery mode (via valid_symbols) and refuse to lex our permissive tokens.

(A tempting alternative is to `return false` when we hit EOF without a delimiter while lexing raw string content, but this fails when the rest of the document happens to contain `")`, which is not so rare.)