### PR TITLE
support attribute in alias declaration

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -664,6 +664,7 @@ module.exports = grammar(C, {
     alias_declaration: $ => seq(
       'using',
       field('name', $._type_identifier),
+      optional($.attribute_declaration),
       '=',
       field('type', $.type_descriptor),
       ';'

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9986,6 +9986,18 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "attribute_declaration"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "="
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -614,6 +614,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_declaration",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -86,6 +86,8 @@ using enum Foo;
 template <typename T>
 using a = typename b<T>::c;
 
+using foobar [[deprecated]] = int;
+
 ---
 
 (translation_unit
@@ -113,7 +115,11 @@ using a = typename b<T>::c;
         (dependent_type
           (qualified_identifier
             (template_type (type_identifier) (template_argument_list (type_descriptor (type_identifier))))
-            (type_identifier)))))))
+            (type_identifier))))))
+  (alias_declaration
+    (type_identifier)
+    (attribute_declaration (attribute (identifier)))
+    (type_descriptor (primitive_type))))
 
 =========================================
 Reference declarations


### PR DESCRIPTION
This commit adds support for

```cpp
using AttrAlias [[deprecated]] = int;
```

Reference: https://en.cppreference.com/w/cpp/language/type_alias