### PR TITLE
Revert "add "this" keyword"

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -60,7 +60,6 @@
  "protected"
  "public"
  "template"
- "this"
  "throw"
  "try"
  "typename"


### PR DESCRIPTION
This reverts commit 086dd299d443cc475de275e9c5d273de1ff1fc21.

My previous PR #202 was based on a misunderstanding on my part, and it causes the tests to fail. Also, the “this” keyword seems to already be supported as a `@variable.builtin`.