### PR TITLE
refactor: remove unused function `skip` in scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -14,8 +14,6 @@ typedef struct {
 
 static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 
-static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
-
 static inline void reset(Scanner *scanner) {
     scanner->delimiter_length = 0;
     memset(scanner->delimiter, 0, sizeof(scanner->delimiter));


### PR DESCRIPTION
This suppresses a warning when using clang for compilation (and probably also with other C compilers).

If `skip` is intended to be kept (e.g. to be consistent with other scanner implementations) the warning could be suppressed using compiler specific pragmas.