### PR TITLE
Fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1177,18 +1177,27 @@ module.exports = grammar(C, {
       $.qualified_identifier,
     ),
 
-    assignment_expression: ($, original) => choice(
-      original,
-      prec.right(PREC.ASSIGNMENT, seq(
-        field('left', $._assignment_left_expression),
-        field('operator', choice(
-          'and_eq',
-          'or_eq',
-          'xor_eq',
-        )),
-        field('right', $._expression),
+    assignment_expression: $ => prec.right(PREC.ASSIGNMENT, seq(
+      field('left', $._assignment_left_expression),
+      field('operator', choice(
+        '=',
+        '*=',
+        '/=',
+        '%=',
+        '+=',
+        '-=',
+        '<<=',
+        '>>=',
+        '&=',
+        '^=',
+        '|=',
+        'and_eq',
+        'or_eq',
+        'xor_eq',
       )),
-    ),
+      field('right', choice($._expression, $.initializer_list)),
+    )),
+
 
     operator_name: $ => prec(1, seq(
       'operator',

--- a/grammar.js
+++ b/grammar.js
@@ -1111,7 +1111,7 @@ module.exports = grammar(C, {
     compound_literal_expression: ($, original) => choice(
       original,
       seq(
-        field('type', $._class_name),
+        field('type', choice($._class_name, $.primitive_type)),
         field('value', $.initializer_list),
       ),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -66,6 +66,7 @@ module.exports = grammar(C, {
     [$._binary_fold_operator, $._fold_operator],
     [$.expression_statement, $.for_statement],
     [$.init_statement, $.for_statement],
+    [$._function_declarator_seq],
   ]),
 
   inline: ($, original) => original.concat([
@@ -571,6 +572,7 @@ module.exports = grammar(C, {
         $.noexcept,
         $.throw_specifier,
       )),
+      repeat($.attribute_specifier),
       repeat($.attribute_declaration),
       optional($.trailing_return_type),
       optional(choice(

--- a/grammar.js
+++ b/grammar.js
@@ -915,19 +915,17 @@ module.exports = grammar(C, {
       $._expression,
     ),
 
-    field_expression: ($, original) => choice(
-      original,
-      seq(
-        prec(PREC.FIELD, seq(
-          field('argument', $._expression),
-          choice('.', '->'),
-        )),
-        field('field', choice(
-          $.destructor_name,
-          $.template_method,
-          alias($.dependent_field_identifier, $.dependent_name),
-        )),
-      ),
+    field_expression: $ => seq(
+      prec(PREC.FIELD, seq(
+        field('argument', $._expression),
+        field('operator', choice('.', '.*', '->')),
+      )),
+      field('field', choice(
+        $._field_identifier,
+        $.destructor_name,
+        $.template_method,
+        alias($.dependent_field_identifier, $.dependent_name),
+      )),
     ),
 
     type_requirement: $ => seq('typename', $._class_name),
@@ -1151,6 +1149,7 @@ module.exports = grammar(C, {
         $.identifier,
         $.operator_name,
         $.destructor_name,
+        $.pointer_type_declarator,
       )),
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -154,7 +154,7 @@ module.exports = grammar(C, {
     // a compound statement. This introduces a shift/reduce conflict that needs to be resolved
     // with an associativity.
     _class_declaration: $ => prec.right(seq(
-      optional($.attribute_specifier),
+      repeat(choice($.attribute_specifier, $.alignas_specifier)),
       optional($.ms_declspec_modifier),
       repeat($.attribute_declaration),
       choice(
@@ -205,9 +205,17 @@ module.exports = grammar(C, {
 
     virtual: _ => choice('virtual'),
 
+    alignas_specifier: $ => seq(
+      'alignas',
+      '(',
+      choice($._expression, $.primitive_type),
+      ')',
+    ),
+
     _declaration_modifiers: ($, original) => choice(
       original,
       $.virtual,
+      $.alignas_specifier,
     ),
 
     explicit_function_specifier: $ => choice(
@@ -843,6 +851,7 @@ module.exports = grammar(C, {
       $.requires_clause,
       $.template_function,
       $.qualified_identifier,
+      $.alignof_expression,
       $.new_expression,
       $.delete_expression,
       $.lambda_expression,
@@ -1067,6 +1076,13 @@ module.exports = grammar(C, {
         field('value', $.identifier),
         ')',
       ),
+    )),
+
+    alignof_expression: $ => prec.right(PREC.SIZEOF, seq(
+      'alignof',
+      '(',
+      field('type', $.type_descriptor),
+      ')',
     )),
 
     unary_expression: ($, original) => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -43,7 +43,6 @@ module.exports = grammar(C, {
 
   conflicts: ($, original) => original.concat([
     [$.template_function, $.template_type],
-    [$.template_function, $.template_type, $._expression],
     [$.template_function, $.template_type, $._expression_not_binary],
     [$.template_function, $.template_type, $.qualified_identifier],
     [$.template_method, $.field_expression],
@@ -51,11 +50,8 @@ module.exports = grammar(C, {
     [$.qualified_type_identifier, $.qualified_identifier],
     [$.dependent_type_identifier, $.dependent_identifier],
     [$.comma_expression, $.initializer_list],
-    [$._expression, $._declarator],
     [$._expression_not_binary, $._declarator],
-    [$._expression, $.structured_binding_declarator],
     [$._expression_not_binary, $.structured_binding_declarator],
-    [$._expression, $._declarator, $._type_specifier],
     [$._expression_not_binary, $._declarator, $._type_specifier],
     [$.parameter_list, $.argument_list],
     [$._type_specifier, $.call_expression],

--- a/grammar.js
+++ b/grammar.js
@@ -154,6 +154,7 @@ module.exports = grammar(C, {
     // a compound statement. This introduces a shift/reduce conflict that needs to be resolved
     // with an associativity.
     _class_declaration: $ => prec.right(seq(
+      optional($.attribute_specifier),
       optional($.ms_declspec_modifier),
       repeat($.attribute_declaration),
       choice(
@@ -165,6 +166,7 @@ module.exports = grammar(C, {
           field('body', $.field_declaration_list),
         ),
       ),
+      optional($.attribute_specifier),
     )),
 
     class_specifier: $ => seq(

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "eslint": "^8.43.0",
     "eslint-config-google": "^0.14.0",
-    "tree-sitter-c": "github:tree-sitter/tree-sitter-c",
+    "tree-sitter-c": "^0.20.4",
     "tree-sitter-cli": "^0.20.8"
   },
   "scripts": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -294,8 +294,11 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\r?\\n"
+          }
         }
       ]
     },
@@ -336,8 +339,11 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\r?\\n"
+          }
         }
       ]
     },
@@ -386,8 +392,11 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\r?\\n"
+          }
         }
       ]
     },
@@ -486,8 +495,11 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\r?\\n"
+          }
         }
       ]
     },
@@ -1138,7 +1150,7 @@
         "value": -1,
         "content": {
           "type": "PATTERN",
-          "value": "\\S(.|\\\\\\r?\\n)*"
+          "value": "\\S([^/\\n]|\\\\\\r?\\n)*"
         }
       }
     },
@@ -2189,6 +2201,10 @@
         {
           "type": "SYMBOL",
           "name": "virtual"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alignas_specifier"
         }
       ]
     },
@@ -5269,6 +5285,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "alignof_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "new_expression"
         },
         {
@@ -5337,7 +5357,7 @@
     },
     "conditional_expression": {
       "type": "PREC_RIGHT",
-      "value": -2,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5423,133 +5443,103 @@
       ]
     },
     "assignment_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC_RIGHT",
-          "value": -1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_assignment_left_expression"
+      "type": "PREC_RIGHT",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_assignment_left_expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "STRING",
+                  "value": "*="
+                },
+                {
+                  "type": "STRING",
+                  "value": "/="
+                },
+                {
+                  "type": "STRING",
+                  "value": "%="
+                },
+                {
+                  "type": "STRING",
+                  "value": "+="
+                },
+                {
+                  "type": "STRING",
+                  "value": "-="
+                },
+                {
+                  "type": "STRING",
+                  "value": "<<="
+                },
+                {
+                  "type": "STRING",
+                  "value": ">>="
+                },
+                {
+                  "type": "STRING",
+                  "value": "&="
+                },
+                {
+                  "type": "STRING",
+                  "value": "^="
+                },
+                {
+                  "type": "STRING",
+                  "value": "|="
+                },
+                {
+                  "type": "STRING",
+                  "value": "and_eq"
+                },
+                {
+                  "type": "STRING",
+                  "value": "or_eq"
+                },
+                {
+                  "type": "STRING",
+                  "value": "xor_eq"
                 }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "*="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "/="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "%="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "+="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "-="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "<<="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": ">>="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "&="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "^="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "|="
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_RIGHT",
-          "value": -1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_assignment_left_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "and_eq"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "or_eq"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "xor_eq"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
                   "type": "SYMBOL",
                   "name": "_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "initializer_list"
                 }
-              }
-            ]
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "pointer_expression": {
       "type": "PREC_LEFT",
@@ -7480,115 +7470,75 @@
       ]
     },
     "field_expression": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PREC",
-              "value": 16,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "argument",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_expression"
+          "type": "PREC",
+          "value": 16,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "argument",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ".*"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "->"
                     }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "operator",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "."
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "->"
-                        }
-                      ]
-                    }
-                  }
-                ]
+                  ]
+                }
               }
-            },
-            {
-              "type": "FIELD",
-              "name": "field",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_field_identifier"
-              }
-            }
-          ]
+            ]
+          }
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PREC",
-              "value": 16,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "argument",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    }
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "."
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "->"
-                      }
-                    ]
-                  }
-                ]
+          "type": "FIELD",
+          "name": "field",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_field_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "destructor_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "template_method"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "dependent_field_identifier"
+                },
+                "named": true,
+                "value": "dependent_name"
               }
-            },
-            {
-              "type": "FIELD",
-              "name": "field",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "destructor_name"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "template_method"
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "dependent_field_identifier"
-                    },
-                    "named": true,
-                    "value": "dependent_name"
-                  }
-                ]
-              }
-            }
-          ]
+            ]
+          }
         }
       ]
     },
@@ -7631,8 +7581,17 @@
               "type": "FIELD",
               "name": "type",
               "content": {
-                "type": "SYMBOL",
-                "name": "_class_name"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_class_name"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "primitive_type"
+                  }
+                ]
               }
             },
             {
@@ -8681,6 +8640,22 @@
         "type": "SEQ",
         "members": [
           {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "attribute_specifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "alignas_specifier"
+                }
+              ]
+            }
+          },
+          {
             "type": "CHOICE",
             "members": [
               {
@@ -8764,6 +8739,18 @@
                 ]
               }
             ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "attribute_specifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
@@ -8826,6 +8813,36 @@
         {
           "type": "STRING",
           "value": "virtual"
+        }
+      ]
+    },
+    "alignas_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "alignas"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "primitive_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },
@@ -10341,6 +10358,13 @@
                 "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "attribute_specifier"
+            }
           },
           {
             "type": "REPEAT",
@@ -13273,6 +13297,35 @@
         }
       ]
     },
+    "alignof_expression": {
+      "type": "PREC_RIGHT",
+      "value": 8,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "alignof"
+          },
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "FIELD",
+            "name": "type",
+            "content": {
+              "type": "SYMBOL",
+              "name": "type_descriptor"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
+    },
     "destructor_name": {
       "type": "PREC",
       "value": 1,
@@ -13465,6 +13518,10 @@
               {
                 "type": "SYMBOL",
                 "name": "destructor_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "pointer_type_declarator"
               }
             ]
           }
@@ -13932,11 +13989,6 @@
     [
       "template_function",
       "template_type",
-      "_expression"
-    ],
-    [
-      "template_function",
-      "template_type",
       "_expression_not_binary"
     ],
     [
@@ -13965,25 +14017,12 @@
       "initializer_list"
     ],
     [
-      "_expression",
-      "_declarator"
-    ],
-    [
       "_expression_not_binary",
       "_declarator"
     ],
     [
-      "_expression",
-      "structured_binding_declarator"
-    ],
-    [
       "_expression_not_binary",
       "structured_binding_declarator"
-    ],
-    [
-      "_expression",
-      "_declarator",
-      "_type_specifier"
     ],
     [
       "_expression_not_binary",
@@ -14032,6 +14071,9 @@
     [
       "init_statement",
       "for_statement"
+    ],
+    [
+      "_function_declarator_seq"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -84,6 +84,10 @@
     "named": true,
     "subtypes": [
       {
+        "type": "alignof_expression",
+        "named": true
+      },
+      {
         "type": "assignment_expression",
         "named": true
       },
@@ -651,6 +655,41 @@
     }
   },
   {
+    "type": "alignas_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "primitive_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alignof_expression",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_descriptor",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "argument_list",
     "named": true,
     "fields": {},
@@ -827,6 +866,10 @@
         "types": [
           {
             "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "initializer_list",
             "named": true
           }
         ]
@@ -1381,7 +1424,15 @@
       "required": false,
       "types": [
         {
+          "type": "alignas_specifier",
+          "named": true
+        },
+        {
           "type": "attribute_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
           "named": true
         },
         {
@@ -1493,6 +1544,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "primitive_type",
+            "named": true
+          },
           {
             "type": "qualified_identifier",
             "named": true
@@ -1991,6 +2046,10 @@
       "required": false,
       "types": [
         {
+          "type": "alignas_specifier",
+          "named": true
+        },
+        {
           "type": "attribute_declaration",
           "named": true
         },
@@ -2421,6 +2480,10 @@
       "required": false,
       "types": [
         {
+          "type": "alignas_specifier",
+          "named": true
+        },
+        {
           "type": "attribute_declaration",
           "named": true
         },
@@ -2575,7 +2638,7 @@
       },
       "operator": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
           {
             "type": "->",
@@ -2583,6 +2646,10 @@
           },
           {
             "type": ".",
+            "named": false
+          },
+          {
+            "type": ".*",
             "named": false
           }
         ]
@@ -2891,6 +2958,10 @@
       "required": false,
       "types": [
         {
+          "type": "alignas_specifier",
+          "named": true
+        },
+        {
           "type": "attribute_declaration",
           "named": true
         },
@@ -3137,6 +3208,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "alignas_specifier",
+          "named": true
+        },
         {
           "type": "attribute_declaration",
           "named": true
@@ -4026,6 +4101,10 @@
       "required": false,
       "types": [
         {
+          "type": "alignas_specifier",
+          "named": true
+        },
+        {
           "type": "attribute_declaration",
           "named": true
         },
@@ -4106,6 +4185,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "alignas_specifier",
+          "named": true
+        },
         {
           "type": "attribute_declaration",
           "named": true
@@ -4192,6 +4275,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "alignas_specifier",
+          "named": true
+        },
         {
           "type": "attribute_declaration",
           "named": true
@@ -4408,6 +4495,40 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "pointer_type_declarator",
+    "named": true,
+    "fields": {
+      "declarator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_type_declarator",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "ms_based_modifier",
+          "named": true
+        },
+        {
+          "type": "ms_pointer_modifier",
+          "named": true
+        },
+        {
+          "type": "type_qualifier",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -5252,6 +5373,10 @@
             "named": true
           },
           {
+            "type": "pointer_type_declarator",
+            "named": true
+          },
+          {
             "type": "qualified_identifier",
             "named": true
           },
@@ -5628,7 +5753,15 @@
       "required": false,
       "types": [
         {
+          "type": "alignas_specifier",
+          "named": true
+        },
+        {
           "type": "attribute_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
           "named": true
         },
         {
@@ -5860,6 +5993,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "alignas_specifier",
+          "named": true
+        },
         {
           "type": "attribute_declaration",
           "named": true
@@ -6453,7 +6590,15 @@
       "required": false,
       "types": [
         {
+          "type": "alignas_specifier",
+          "named": true
+        },
+        {
           "type": "attribute_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
           "named": true
         },
         {
@@ -6603,6 +6748,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "alignas_specifier",
+          "named": true
+        },
         {
           "type": "attribute_declaration",
           "named": true
@@ -7023,6 +7172,14 @@
   },
   {
     "type": "_unaligned",
+    "named": false
+  },
+  {
+    "type": "alignas",
+    "named": false
+  },
+  {
+    "type": "alignof",
     "named": false
   },
   {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -2172,3 +2172,99 @@ int main() {
       (comment)
       (return_statement
         (number_literal)))))
+
+================================================================================
+Alignas specifier and alignof expression
+================================================================================
+
+struct sse_t {
+    alignas(16) float sse_data[4];
+};
+
+struct data {
+    char x;
+    alignas(128) char cacheline[128]; // over-aligned array of char,
+                                      // not array of over-aligned chars
+};
+
+int main(void) {
+    printf("sizeof(data) = %zu (1 byte + 127 bytes padding + 128-byte array)\n",
+           sizeof(struct data));
+
+    printf("alignment of sse_t is %zu\n", alignof(struct sse_t));
+
+    alignas(2048) struct data d; // this instance of data is aligned even stricter
+    (void)d; // suppresses "maybe unused" warning
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (struct_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (alignas_specifier
+          (number_literal))
+        (primitive_type)
+        (array_declarator
+          (field_identifier)
+          (number_literal)))))
+  (struct_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (primitive_type)
+        (field_identifier))
+      (field_declaration
+        (alignas_specifier
+          (number_literal))
+        (primitive_type)
+        (array_declarator
+          (field_identifier)
+          (number_literal)))
+      (comment)
+      (comment)))
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (primitive_type))))
+    (compound_statement
+      (expression_statement
+        (call_expression
+          (identifier)
+          (argument_list
+            (string_literal
+              (string_content)
+              (escape_sequence))
+            (sizeof_expression
+              (type_descriptor
+                (struct_specifier
+                  (type_identifier)))))))
+      (expression_statement
+        (call_expression
+          (identifier)
+          (argument_list
+            (string_literal
+              (string_content)
+              (escape_sequence))
+            (alignof_expression
+              (type_descriptor
+                (struct_specifier
+                  (type_identifier)))))))
+      (declaration
+        (alignas_specifier
+          (number_literal))
+        (struct_specifier
+          (type_identifier))
+        (identifier))
+      (comment)
+      (expression_statement
+        (cast_expression
+          (type_descriptor
+            (primitive_type))
+          (identifier)))
+      (comment))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -2268,3 +2268,32 @@ int main(void) {
             (primitive_type))
           (identifier)))
       (comment))))
+
+================================================================================
+Attribute specifier after noexcept
+================================================================================
+
+inline constexpr MyEnum operator|(MyEnum bit0, MyEnum bit1) noexcept
+    __attribute__((always_inline)) {}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (storage_class_specifier)
+    (type_qualifier)
+    (type_identifier)
+    (function_declarator
+      (operator_name)
+      (parameter_list
+        (parameter_declaration
+          (type_identifier)
+          (identifier))
+        (parameter_declaration
+          (type_identifier)
+          (identifier)))
+      (noexcept)
+      (attribute_specifier
+        (argument_list
+          (identifier))))
+    (compound_statement)))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -2091,3 +2091,84 @@ struct A {
                   (type_qualifier)
                   (abstract_reference_declarator))))
             (identifier)))))))
+
+================================================================================
+Pointers in qualified identifiers and field expressions
+================================================================================
+
+class MyClass {
+  public:
+    int memberFunction(int value) {
+        return value * 2;
+    }
+};
+
+int main() {
+    void (MyClass::*member_function_ptr)(int);
+    MyClass obj;
+
+    member_function_ptr = &MyClass::memberFunction;
+
+    (obj.*member_function_ptr)(42); // 84
+
+    return 0;
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (class_specifier
+    (type_identifier)
+    (field_declaration_list
+      (access_specifier)
+      (function_definition
+        (primitive_type)
+        (function_declarator
+          (field_identifier)
+          (parameter_list
+            (parameter_declaration
+              (primitive_type)
+              (identifier))))
+        (compound_statement
+          (return_statement
+            (binary_expression
+              (identifier)
+              (number_literal)))))))
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list))
+    (compound_statement
+      (declaration
+        (primitive_type)
+        (function_declarator
+          (parenthesized_declarator
+            (qualified_identifier
+              (namespace_identifier)
+              (pointer_type_declarator
+                (type_identifier))))
+          (parameter_list
+            (parameter_declaration
+              (primitive_type)))))
+      (declaration
+        (type_identifier)
+        (identifier))
+      (expression_statement
+        (assignment_expression
+          (identifier)
+          (pointer_expression
+            (qualified_identifier
+              (namespace_identifier)
+              (identifier)))))
+      (expression_statement
+        (call_expression
+          (parenthesized_expression
+            (field_expression
+              (identifier)
+              (field_identifier)))
+          (argument_list
+            (number_literal))))
+      (comment)
+      (return_statement
+        (number_literal)))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -237,6 +237,40 @@ int main() {
               (false))))))))
 
 ================================================================================
+Initializer list as assignment expression RHS
+================================================================================
+
+void test() {
+    int b = int{1};
+    b = int{2};
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list))
+    (compound_statement
+      (declaration
+        (primitive_type)
+        (init_declarator
+          (identifier)
+          (compound_literal_expression
+            (primitive_type)
+            (initializer_list
+              (number_literal)))))
+      (expression_statement
+        (assignment_expression
+          (identifier)
+          (compound_literal_expression
+            (primitive_type)
+            (initializer_list
+              (number_literal))))))))
+
+================================================================================
 Lambda expressions
 ================================================================================
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -32,6 +32,7 @@ Compound literals without parentheses
 
 T x = T{0};
 U<V> y = U<V>{0};
+int x = int{1};
 
 --------------------------------------------------------------------------------
 
@@ -58,6 +59,14 @@ U<V> y = U<V>{0};
           (template_argument_list
             (type_descriptor
               (type_identifier))))
+        (initializer_list
+          (number_literal)))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (compound_literal_expression
+        (primitive_type)
         (initializer_list
           (number_literal))))))
 


### PR DESCRIPTION
Did this to prep for another release, and most of these were easy enough to fix and aren't anything complicated.

The main change that really increased state count a bit is backporting the C updates where I added attribute_specifier to more allowed locations. 

Closes #47 
Closes #63 (really a C bug fixed in 0.20.4)
Closes #96 
Closes #102 
Closes #103 
Closes #112 
Closes #139 
Closes #203 

The last issue that's a bit difficult is the parenthesized assignment expressions, that's because of fold operators taking precedence over them but I could not figure that out, I'll try a bit more anyways