### PR TITLE
Support multidimensional subscripts

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -880,11 +880,14 @@ module.exports = grammar(C, {
 
     subscript_expression: $ => prec(PREC.SUBSCRIPT, seq(
       field('argument', $._expression),
-      '[',
-      field('index', choice($._expression, $.initializer_list)),
-      ']',
+      field('indices', $.subscript_argument_list),
     )),
 
+    subscript_argument_list: $ => seq(
+      '[',
+      commaSep(choice($._expression, $.initializer_list)),
+      ']',
+    ),
 
     call_expression: ($, original) => choice(original, seq(
       field('function', $.primitive_type),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6861,29 +6861,12 @@
             }
           },
           {
-            "type": "STRING",
-            "value": "["
-          },
-          {
             "type": "FIELD",
-            "name": "index",
+            "name": "indices",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "initializer_list"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "subscript_argument_list"
             }
-          },
-          {
-            "type": "STRING",
-            "value": "]"
           }
         ]
       }
@@ -11436,6 +11419,70 @@
         {
           "type": "STRING",
           "value": "\""
+        }
+      ]
+    },
+    "subscript_argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "initializer_list"
+                    }
+                  ]
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "initializer_list"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5795,6 +5795,25 @@
     }
   },
   {
+    "type": "subscript_argument_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "initializer_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "subscript_designator",
     "named": true,
     "fields": {},
@@ -5823,16 +5842,12 @@
           }
         ]
       },
-      "index": {
+      "indices": {
         "multiple": false,
         "required": true,
         "types": [
           {
-            "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "initializer_list",
+            "type": "subscript_argument_list",
             "named": true
           }
         ]

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1168,22 +1168,26 @@ array_[{i}] = s[{1,2,3}];
     (assignment_expression
       (subscript_expression
         (identifier)
-        (identifier))
+        (subscript_argument_list
+          (identifier)))
       (subscript_expression
         (identifier)
-        (identifier))))
+        (subscript_argument_list
+          (identifier)))))
   (expression_statement
     (assignment_expression
       (subscript_expression
         (identifier)
-        (initializer_list
-          (identifier)))
+        (subscript_argument_list
+          (initializer_list
+            (identifier))))
       (subscript_expression
         (identifier)
-        (initializer_list
-          (number_literal)
-          (number_literal)
-          (number_literal))))))
+        (subscript_argument_list
+          (initializer_list
+            (number_literal)
+            (number_literal)
+            (number_literal)))))))
 
 ================================================================================
 Coroutines
@@ -1330,3 +1334,24 @@ foo and_eq bar();
       (call_expression
         (identifier)
         (argument_list)))))
+
+================================================================================
+Subscript expression
+================================================================================
+
+auto x = a[1, 2, 3];
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (placeholder_type_specifier
+      (auto))
+    (init_declarator
+      (identifier)
+      (subscript_expression
+        (identifier)
+        (subscript_argument_list
+          (number_literal)
+          (number_literal)
+          (number_literal))))))


### PR DESCRIPTION
This change allows commas inside subscripts.

```cpp
auto x = a[1, 2, 3];
```

From C++23, array subscripts work like arguments to `operator[]` as an n-ary function.

Before C++23, `operator[]` must be a unary function, but before C++20, it's possible to use the comma operator inside subscript expressions - and this is done in libraries that use expression templates to achieve multidimensional array syntax.

Use of the comma operator in subscript expressions was deprecated in C++20 to make way for the C++23 change to n-ary `operator[]`.