### PR TITLE
Support dependent operator templates

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -620,7 +620,7 @@ module.exports = grammar(C, {
     ),
 
     template_method: $ => seq(
-      field('name', $._field_identifier),
+      field('name', choice($._field_identifier, $.operator_name)),
       field('arguments', $.template_argument_list),
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10537,8 +10537,17 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "SYMBOL",
-            "name": "_field_identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_field_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator_name"
+              }
+            ]
           }
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6060,6 +6060,10 @@
           {
             "type": "field_identifier",
             "named": true
+          },
+          {
+            "type": "operator_name",
+            "named": true
           }
         ]
       }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1355,3 +1355,24 @@ auto x = a[1, 2, 3];
           (number_literal)
           (number_literal)
           (number_literal))))))
+
+================================================================================
+Dependent operator templates
+================================================================================
+
+x.template operator()<int>();
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expression_statement
+    (call_expression
+      (field_expression
+        (identifier)
+        (dependent_name
+          (template_method
+            (operator_name)
+            (template_argument_list
+              (type_descriptor
+                (primitive_type))))))
+      (argument_list))))


### PR DESCRIPTION
This change allows operators (not just fields/member functions) as dependent template expressions.

```cpp
auto x = y.template operator()<int>();
```

This syntax is used e.g. to call C++20 lambda expressions with a template head where the template arguments are not function arguments and therefore cannot be deduced.

```cpp
[]<typename> () {}.template operator()<int>();
```