### PR TITLE
Add TAGS_QUERY to rust bindings

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -55,7 +55,7 @@ pub const HIGHLIGHT_QUERY: &str = include_str!("../../queries/highlights.scm");
 pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 /// The symbol tagging query for this language.
-pub const TAGGING_QUERY: &'static str = include_str!("../../queries/tags.scm");
+pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -54,6 +54,9 @@ pub const HIGHLIGHT_QUERY: &str = include_str!("../../queries/highlights.scm");
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
+/// The symbol tagging query for this language.
+pub const TAGGING_QUERY: &'static str = include_str!("../../queries/tags.scm");
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
Context: `TAGS_QUERY`/`TAGGING_QUERY` as a const is used by [Tabby](https://github.com/TabbyML/tabby) for LLM-based autocompletion. Other `tree-sitter` libraries for other languages expose this constant: [`tree-sitter-ruby`](https://github.com/tree-sitter/tree-sitter-ruby/blob/f257f3f57833d584050336921773738a3fd8ca22/bindings/rust/lib.rs#L61), [`tree-sitter-go`](https://github.com/tree-sitter/tree-sitter-go/blob/ff86c7f1734873c8c4874ca4dd95603695686d7a/bindings/rust/lib.rs#L57), etc.

Exposing the same const for `tree-sitter-cpp`.

Related: https://github.com/tree-sitter/tree-sitter-c/pull/173