### PR TITLE
disambiguate fold vs parenthesized assignment

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -33,6 +33,23 @@ const FOLD_OPERATORS = [
   'or', 'and', 'bitor', 'xor', 'bitand', 'not_eq',
 ];
 
+const ASSIGNMENT_OPERATORS = [
+  '=',
+  '*=',
+  '/=',
+  '%=',
+  '+=',
+  '-=',
+  '<<=',
+  '>>=',
+  '&=',
+  '^=',
+  '|=',
+  'and_eq',
+  'or_eq',
+  'xor_eq',
+]
+
 module.exports = grammar(C, {
   name: 'cpp',
 
@@ -1225,25 +1242,22 @@ module.exports = grammar(C, {
 
     assignment_expression: $ => prec.right(PREC.ASSIGNMENT, seq(
       field('left', $._assignment_left_expression),
-      field('operator', choice(
-        '=',
-        '*=',
-        '/=',
-        '%=',
-        '+=',
-        '-=',
-        '<<=',
-        '>>=',
-        '&=',
-        '^=',
-        '|=',
-        'and_eq',
-        'or_eq',
-        'xor_eq',
-      )),
+      field('operator', choice(...ASSIGNMENT_OPERATORS)),
       field('right', choice($._expression, $.initializer_list)),
     )),
 
+    assignment_expression_lhs_expression: $ => seq(
+      field('left', $._expression),
+      field('operator', choice(...ASSIGNMENT_OPERATORS)),
+      field('right', choice($._expression, $.initializer_list)),
+    ),
+
+    // This prevents an ambiguity between fold expressions
+    // and assignment expressions within parentheses.
+    parenthesized_expression: ($, original) => choice(
+      original,
+      seq('(', $.assignment_expression_lhs_expression, ')')
+    ),
 
     operator_name: $ => prec(1, seq(
       'operator',

--- a/grammar.js
+++ b/grammar.js
@@ -1256,7 +1256,7 @@ module.exports = grammar(C, {
     // and assignment expressions within parentheses.
     parenthesized_expression: ($, original) => choice(
       original,
-      seq('(', $.assignment_expression_lhs_expression, ')')
+      seq('(', alias($.assignment_expression_lhs_expression, $.assignment_expression), ')')
     ),
 
     operator_name: $ => prec(1, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9118,28 +9118,50 @@
       ]
     },
     "parenthesized_expression": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "STRING",
+              "value": "("
             },
             {
-              "type": "SYMBOL",
-              "name": "comma_expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "comma_expression"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
             }
           ]
         },
         {
-          "type": "STRING",
-          "value": ")"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "assignment_expression_lhs_expression"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
         }
       ]
     },
@@ -15840,6 +15862,101 @@
               {
                 "type": "SYMBOL",
                 "name": "operator_cast"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "assignment_expression_lhs_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "left",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "operator",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "="
+              },
+              {
+                "type": "STRING",
+                "value": "*="
+              },
+              {
+                "type": "STRING",
+                "value": "/="
+              },
+              {
+                "type": "STRING",
+                "value": "%="
+              },
+              {
+                "type": "STRING",
+                "value": "+="
+              },
+              {
+                "type": "STRING",
+                "value": "-="
+              },
+              {
+                "type": "STRING",
+                "value": "<<="
+              },
+              {
+                "type": "STRING",
+                "value": ">>="
+              },
+              {
+                "type": "STRING",
+                "value": "&="
+              },
+              {
+                "type": "STRING",
+                "value": "^="
+              },
+              {
+                "type": "STRING",
+                "value": "|="
+              },
+              {
+                "type": "STRING",
+                "value": "and_eq"
+              },
+              {
+                "type": "STRING",
+                "value": "or_eq"
+              },
+              {
+                "type": "STRING",
+                "value": "xor_eq"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "right",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "initializer_list"
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9154,8 +9154,13 @@
               "value": "("
             },
             {
-              "type": "SYMBOL",
-              "name": "assignment_expression_lhs_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "assignment_expression_lhs_expression"
+              },
+              "named": true,
+              "value": "assignment_expression"
             },
             {
               "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -897,6 +897,98 @@
     }
   },
   {
+    "type": "assignment_expression_lhs_expression",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "%=",
+            "named": false
+          },
+          {
+            "type": "&=",
+            "named": false
+          },
+          {
+            "type": "*=",
+            "named": false
+          },
+          {
+            "type": "+=",
+            "named": false
+          },
+          {
+            "type": "-=",
+            "named": false
+          },
+          {
+            "type": "/=",
+            "named": false
+          },
+          {
+            "type": "<<=",
+            "named": false
+          },
+          {
+            "type": "=",
+            "named": false
+          },
+          {
+            "type": ">>=",
+            "named": false
+          },
+          {
+            "type": "^=",
+            "named": false
+          },
+          {
+            "type": "and_eq",
+            "named": false
+          },
+          {
+            "type": "or_eq",
+            "named": false
+          },
+          {
+            "type": "xor_eq",
+            "named": false
+          },
+          {
+            "type": "|=",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "initializer_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "attribute",
     "named": true,
     "fields": {
@@ -4464,6 +4556,10 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "assignment_expression_lhs_expression",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -785,126 +785,6 @@
         "required": true,
         "types": [
           {
-            "type": "call_expression",
-            "named": true
-          },
-          {
-            "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
-            "named": true
-          },
-          {
-            "type": "pointer_expression",
-            "named": true
-          },
-          {
-            "type": "qualified_identifier",
-            "named": true
-          },
-          {
-            "type": "subscript_expression",
-            "named": true
-          },
-          {
-            "type": "user_defined_literal",
-            "named": true
-          }
-        ]
-      },
-      "operator": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "%=",
-            "named": false
-          },
-          {
-            "type": "&=",
-            "named": false
-          },
-          {
-            "type": "*=",
-            "named": false
-          },
-          {
-            "type": "+=",
-            "named": false
-          },
-          {
-            "type": "-=",
-            "named": false
-          },
-          {
-            "type": "/=",
-            "named": false
-          },
-          {
-            "type": "<<=",
-            "named": false
-          },
-          {
-            "type": "=",
-            "named": false
-          },
-          {
-            "type": ">>=",
-            "named": false
-          },
-          {
-            "type": "^=",
-            "named": false
-          },
-          {
-            "type": "and_eq",
-            "named": false
-          },
-          {
-            "type": "or_eq",
-            "named": false
-          },
-          {
-            "type": "xor_eq",
-            "named": false
-          },
-          {
-            "type": "|=",
-            "named": false
-          }
-        ]
-      },
-      "right": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "initializer_list",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "assignment_expression_lhs_expression",
-    "named": true,
-    "fields": {
-      "left": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
             "type": "_expression",
             "named": true
           }
@@ -4556,10 +4436,6 @@
       "types": [
         {
           "type": "_expression",
-          "named": true
-        },
-        {
-          "type": "assignment_expression_lhs_expression",
           "named": true
         },
         {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -129,16 +130,9 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -172,7 +166,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -182,7 +176,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -190,7 +184,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1478,7 +1478,7 @@ while ((a = b)) {}
   (while_statement
     (condition_clause
       (parenthesized_expression
-        (assignment_expression_lhs_expression
+        (assignment_expression
           (identifier)
           (identifier))))
     (compound_statement)))
@@ -1505,7 +1505,7 @@ int main() {
       (if_statement
         (condition_clause
           (parenthesized_expression
-            (assignment_expression_lhs_expression
+            (assignment_expression
               (identifier)
               (binary_expression
                 (identifier)
@@ -1514,7 +1514,7 @@ int main() {
           (expression_statement
             (assignment_expression
               (parenthesized_expression
-                (assignment_expression_lhs_expression
+                (assignment_expression
                   (identifier)
                   (number_literal)))
               (number_literal))))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1465,3 +1465,94 @@ void f() {
         (number_literal))
       (expression_statement
         (number_literal)))))
+
+================================================================================
+While with assignment expression
+================================================================================
+
+while ((a = b)) {}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (while_statement
+    (condition_clause
+      (parenthesized_expression
+        (assignment_expression_lhs_expression
+          (identifier)
+          (identifier))))
+    (compound_statement)))
+
+================================================================================
+Parenthesized Expressions that are not Fold Expressions
+================================================================================
+
+int main() {
+  if ((a = a + 1)) {
+    (a += 1) %= 2;
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list))
+    (compound_statement
+      (if_statement
+        (condition_clause
+          (parenthesized_expression
+            (assignment_expression_lhs_expression
+              (identifier)
+              (binary_expression
+                (identifier)
+                (number_literal)))))
+        (compound_statement
+          (expression_statement
+            (assignment_expression
+              (parenthesized_expression
+                (assignment_expression_lhs_expression
+                  (identifier)
+                  (number_literal)))
+              (number_literal))))))))
+
+================================================================================
+Complex fold expression
+================================================================================
+
+template <typename... Args> void negateValues(Args... args) {
+  ((std::cout << !args << " "), ...);
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (template_declaration
+    (template_parameter_list
+      (variadic_type_parameter_declaration
+        (type_identifier)))
+    (function_definition
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list
+          (variadic_parameter_declaration
+            (type_identifier)
+            (variadic_declarator
+              (identifier)))))
+      (compound_statement
+        (expression_statement
+          (fold_expression
+            (parenthesized_expression
+              (binary_expression
+                (binary_expression
+                  (qualified_identifier
+                    (namespace_identifier)
+                    (identifier))
+                  (unary_expression
+                    (identifier)))
+                (string_literal
+                  (string_content))))))))))


### PR DESCRIPTION
Currently, there is an ambiguity in parsing fold expressions and parenthesized assignment expressions. This is described in issues #201 and #212.

This arises in the following trace:
```
( <id>    =
       ^ where we are here
```

The crux of the issue is that we do not know whether to shift the `=` forward, or to reduce the `<id>` to an `expression_not_binary`. If we do the former, we can no longer parse a fold expression, which expects `<exp> <fold_operator> '...'`. If we do the latter, we can no longer parse a parenthesized assignment expression, as an assignment expression does not permit arbitrary expressions to appear on the LHS.

The current behavior is that `tree-sitter-cpp` will reduce the `<id>`, and thus fail to parse any parenthesized assignment expression. Unfortunately, these are reasonably common, so this is actually disastrous.

This PR makes it so that parenthesized expressions specifically allow assignment expressions which feature expressions on the LHS, so that it can still parse even if we reduce the identifier. This causes the grammar to be a little more permissive than it needs to be, but it does not disallow valid programs, as [another proposed solution](https://github.com/tree-sitter/tree-sitter-cpp/pull/219) to this problem does.

I believe it is better for us to be more permissive, in this case, so that we no longer disallow valid programs, with the understanding that we can restore stringency at a later date.