### PR TITLE
Add node-gyp 10 to dev dependencies to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "eslint": "^8.56.0",
     "eslint-config-google": "^0.14.0",
     "tree-sitter-c": "^0.20.7",
-    "tree-sitter-cli": "^0.20.8"
+    "tree-sitter-cli": "^0.20.8",
+    "node-gyp": "^10.0.1"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",


### PR DESCRIPTION
Running `npm run build` was defaulting to node's `node-gyp` version (apparently 9.x on my machine):

```shell
$ npm install
...
npm ERR! gyp info using node-gyp@9.4.0
npm ERR! gyp info using node@20.6.1 | darwin | arm64
...
Dnode_gyp_dir=/Users/khiner/.nvm/versions/node/v20.6.1/lib/node_modules/npm/node_modules/node-gyp',
```

This PR follows the config in the `package.json` of [tree-sitter-json](https://github.com/tree-sitter/tree-sitter-json), which I understand to be a good standard since it's used as an example in tree-sitter's documentation.
