### PR TITLE
Fix parsing of calls of overloaded operators

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1006,6 +1006,8 @@ module.exports = grammar(C, {
         alias($.qualified_field_identifier, $.qualified_identifier),
         $.destructor_name,
         $.template_method,
+        $.operator_name,
+        $.operator_cast,
         alias($.dependent_field_identifier, $.dependent_name),
       )),
     )),
@@ -1220,6 +1222,7 @@ module.exports = grammar(C, {
         alias($.qualified_field_identifier, $.qualified_identifier),
         $.template_method,
         $._field_identifier,
+        $.operator_name,
       )),
     )),
 


### PR DESCRIPTION
Here is a shortened version of my code, which couldn't be parsed correctly.
This is my first time editing a tree-sitter grammar. Maybe I accidentally broke the parsing of other code.

```c++

struct base{

};

struct other{
    int i{};
    int square(){return i*i;}
};

struct derived : public base {
    derived & operator=(const base& b){
        this->
            base::operator= // HERE: qualified_field_identifier
            (b);
        return *this;
    }

    operator other(){
        return other{4};
    }

    int square(){
        return this->
            operator other // HERE: operator_cast
            ().square();
    }

};

```

tree with errors:
```
(struct_specifier) ; [2:1 - 4:1]
 name: (type_identifier) ; [2:8 - 11]
 body: (field_declaration_list) ; [2:12 - 4:1]
(struct_specifier) ; [6:1 - 9:1]
 name: (type_identifier) ; [6:8 - 12]
 body: (field_declaration_list) ; [6:13 - 9:1]
  (field_declaration) ; [7:5 - 12]
   type: (primitive_type) ; [7:5 - 7]
   declarator: (field_identifier) ; [7:9 - 9]
   default_value: (initializer_list) ; [7:10 - 11]
  (function_definition) ; [8:5 - 29]
   type: (primitive_type) ; [8:5 - 7]
   declarator: (function_declarator) ; [8:9 - 16]
    declarator: (field_identifier) ; [8:9 - 14]
    parameters: (parameter_list) ; [8:15 - 16]
   body: (compound_statement) ; [8:17 - 29]
    (return_statement) ; [8:18 - 28]
     (binary_expression) ; [8:25 - 27]
      left: (identifier) ; [8:25 - 25]
      right: (identifier) ; [8:27 - 27]
(struct_specifier) ; [11:1 - 29:1]
 name: (type_identifier) ; [11:8 - 14]
 (base_class_clause) ; [11:16 - 28]
  (access_specifier) ; [11:18 - 23]
  (type_identifier) ; [11:25 - 28]
 body: (field_declaration_list) ; [11:30 - 29:1]
  (function_definition) ; [12:5 - 17:5]
   type: (type_identifier) ; [12:5 - 11]
   declarator: (reference_declarator) ; [12:13 - 38]
    (function_declarator) ; [12:15 - 38]
     declarator: (operator_name) ; [12:15 - 23]
     parameters: (parameter_list) ; [12:24 - 38]
      (parameter_declaration) ; [12:25 - 37]
       (type_qualifier) ; [12:25 - 29]
       type: (type_identifier) ; [12:31 - 34]
       declarator: (reference_declarator) ; [12:35 - 37]
        (identifier) ; [12:37 - 37]
   body: (compound_statement) ; [12:39 - 17:5]
    (expression_statement) ; [13:9 - 15:16]
     (call_expression) ; [13:9 - 15:15]
      function: (this) ; [13:9 - 12]
      (ERROR) ; [13:13 - 14:27]
       scope: (namespace_identifier) ; [14:13 - 16]
       (operator_name) ; [14:19 - 27]
      (comment) ; [14:29 - 63]
      arguments: (argument_list) ; [15:13 - 15]
       (identifier) ; [15:14 - 14]
    (return_statement) ; [16:9 - 21]
     (pointer_expression) ; [16:16 - 20]
      argument: (this) ; [16:17 - 20]
  (function_definition) ; [19:5 - 21:5]
   declarator: (operator_cast) ; [19:5 - 20]
    type: (type_identifier) ; [19:14 - 18]
    declarator: (abstract_function_declarator) ; [19:19 - 20]
     parameters: (parameter_list) ; [19:19 - 20]
   body: (compound_statement) ; [19:21 - 21:5]
    (return_statement) ; [20:9 - 24]
     (compound_literal_expression) ; [20:16 - 23]
      type: (type_identifier) ; [20:16 - 20]
      value: (initializer_list) ; [20:21 - 23]
       (number_literal) ; [20:22 - 22]
  (function_definition) ; [23:5 - 27:5]
   type: (primitive_type) ; [23:5 - 7]
   declarator: (function_declarator) ; [23:9 - 16]
    declarator: (field_identifier) ; [23:9 - 14]
    parameters: (parameter_list) ; [23:15 - 16]
   body: (compound_statement) ; [23:17 - 27:5]
    (return_statement) ; [24:9 - 26:24]
     (call_expression) ; [24:16 - 26:23]
      function: (field_expression) ; [24:16 - 26:21]
       argument: (call_expression) ; [24:16 - 26:14]
        function: (field_expression) ; [24:16 - 25:26]
         argument: (this) ; [24:16 - 19]
         (ERROR) ; [25:13 - 20]
         field: (field_identifier) ; [25:22 - 26]
        (comment) ; [25:28 - 49]
        arguments: (argument_list) ; [26:13 - 14]
       field: (field_identifier) ; [26:16 - 21]
      arguments: (argument_list) ; [26:22 - 23]
```

fixed tree:
```
(struct_specifier) ; [2:1 - 4:1]
 name: (type_identifier) ; [2:8 - 11]
 body: (field_declaration_list) ; [2:12 - 4:1]
(struct_specifier) ; [6:1 - 9:1]
 name: (type_identifier) ; [6:8 - 12]
 body: (field_declaration_list) ; [6:13 - 9:1]
  (field_declaration) ; [7:5 - 12]
   type: (primitive_type) ; [7:5 - 7]
   declarator: (field_identifier) ; [7:9 - 9]
   default_value: (initializer_list) ; [7:10 - 11]
  (function_definition) ; [8:5 - 29]
   type: (primitive_type) ; [8:5 - 7]
   declarator: (function_declarator) ; [8:9 - 16]
    declarator: (field_identifier) ; [8:9 - 14]
    parameters: (parameter_list) ; [8:15 - 16]
   body: (compound_statement) ; [8:17 - 29]
    (return_statement) ; [8:18 - 28]
     (binary_expression) ; [8:25 - 27]
      left: (identifier) ; [8:25 - 25]
      right: (identifier) ; [8:27 - 27]
(struct_specifier) ; [11:1 - 29:1]
 name: (type_identifier) ; [11:8 - 14]
 (base_class_clause) ; [11:16 - 28]
  (access_specifier) ; [11:18 - 23]
  (type_identifier) ; [11:25 - 28]
 body: (field_declaration_list) ; [11:30 - 29:1]
  (function_definition) ; [12:5 - 17:5]
   type: (type_identifier) ; [12:5 - 11]
   declarator: (reference_declarator) ; [12:13 - 38]
    (function_declarator) ; [12:15 - 38]
     declarator: (operator_name) ; [12:15 - 23]
     parameters: (parameter_list) ; [12:24 - 38]
      (parameter_declaration) ; [12:25 - 37]
       (type_qualifier) ; [12:25 - 29]
       type: (type_identifier) ; [12:31 - 34]
       declarator: (reference_declarator) ; [12:35 - 37]
        (identifier) ; [12:37 - 37]
   body: (compound_statement) ; [12:39 - 17:5]
    (expression_statement) ; [13:9 - 15:16]
     (call_expression) ; [13:9 - 15:15]
      function: (field_expression) ; [13:9 - 14:27]
       argument: (this) ; [13:9 - 12]
       field: (qualified_identifier) ; [14:13 - 27]
        scope: (namespace_identifier) ; [14:13 - 16]
        name: (operator_name) ; [14:19 - 27]
      (comment) ; [14:29 - 63]
      arguments: (argument_list) ; [15:13 - 15]
       (identifier) ; [15:14 - 14]
    (return_statement) ; [16:9 - 21]
     (pointer_expression) ; [16:16 - 20]
      argument: (this) ; [16:17 - 20]
  (function_definition) ; [19:5 - 21:5]
   declarator: (operator_cast) ; [19:5 - 20]
    type: (type_identifier) ; [19:14 - 18]
    declarator: (abstract_function_declarator) ; [19:19 - 20]
     parameters: (parameter_list) ; [19:19 - 20]
   body: (compound_statement) ; [19:21 - 21:5]
    (return_statement) ; [20:9 - 24]
     (compound_literal_expression) ; [20:16 - 23]
      type: (type_identifier) ; [20:16 - 20]
      value: (initializer_list) ; [20:21 - 23]
       (number_literal) ; [20:22 - 22]
  (function_definition) ; [23:5 - 27:5]
   type: (primitive_type) ; [23:5 - 7]
   declarator: (function_declarator) ; [23:9 - 16]
    declarator: (field_identifier) ; [23:9 - 14]
    parameters: (parameter_list) ; [23:15 - 16]
   body: (compound_statement) ; [23:17 - 27:5]
    (return_statement) ; [24:9 - 26:24]
     (call_expression) ; [24:16 - 26:23]
      function: (field_expression) ; [24:16 - 26:21]
       argument: (field_expression) ; [24:16 - 26:14]
        argument: (this) ; [24:16 - 19]
        field: (operator_cast) ; [25:13 - 26:14]
         type: (type_identifier) ; [25:22 - 26]
         (comment) ; [25:28 - 49]
         declarator: (abstract_function_declarator) ; [26:13 - 14]
          parameters: (parameter_list) ; [26:13 - 14]
       field: (field_identifier) ; [26:16 - 21]
      arguments: (argument_list) ; [26:22 - 23]
```