### PR TITLE
Fixing ambiguities between template methods and comparisons

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -86,6 +86,8 @@ module.exports = grammar(C, {
     [$.initializer_pair, $.comma_expression],
     [$.expression_statement, $._for_statement_body],
     [$.init_statement, $._for_statement_body],
+    [$.field_expression, $.template_method, $.template_type],
+    [$.qualified_field_identifier, $.template_method, $.template_type],
   ],
 
   inline: ($, original) => original.concat([
@@ -998,19 +1000,19 @@ module.exports = grammar(C, {
       $.expression,
     ),
 
-    field_expression: $ => prec.right(seq(
+    field_expression: $ => seq(
       prec(PREC.FIELD, seq(
         field('argument', $.expression),
         field('operator', choice('.', '.*', '->')),
       )),
       field('field', choice(
-        $._field_identifier,
+        prec.dynamic(1, $._field_identifier),
         alias($.qualified_field_identifier, $.qualified_identifier),
         $.destructor_name,
         $.template_method,
         alias($.dependent_field_identifier, $.dependent_name),
       )),
-    )),
+    ),
 
     type_requirement: $ => seq('typename', $._class_name),
 
@@ -1215,15 +1217,15 @@ module.exports = grammar(C, {
       '::',
     )),
 
-    qualified_field_identifier: $ => prec.right(seq(
+    qualified_field_identifier: $ => seq(
       $._scope_resolution,
       field('name', choice(
         alias($.dependent_field_identifier, $.dependent_name),
         alias($.qualified_field_identifier, $.qualified_identifier),
         $.template_method,
-        $._field_identifier,
+        prec.dynamic(1, $._field_identifier),
       )),
-    )),
+    ),
 
     qualified_identifier: $ => seq(
       $._scope_resolution,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,6 +1,6 @@
 {
+  "0": "c",
   "name": "cpp",
-  "inherits": "c",
   "word": "identifier",
   "rules": {
     "translation_unit": {
@@ -9330,90 +9330,90 @@
       ]
     },
     "field_expression": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "PREC",
-            "value": 16,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "argument",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "expression"
-                  }
-                },
-                {
-                  "type": "FIELD",
-                  "name": "operator",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "."
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ".*"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "->"
-                      }
-                    ]
-                  }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 16,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "argument",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
                 }
-              ]
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "field",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ".*"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "->"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "field",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_DYNAMIC",
+                "value": 1,
+                "content": {
                   "type": "SYMBOL",
                   "name": "_field_identifier"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "qualified_field_identifier"
-                  },
-                  "named": true,
-                  "value": "qualified_identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "destructor_name"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "template_method"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "dependent_field_identifier"
-                  },
-                  "named": true,
-                  "value": "dependent_name"
                 }
-              ]
-            }
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "qualified_field_identifier"
+                },
+                "named": true,
+                "value": "qualified_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "destructor_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "template_method"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "dependent_field_identifier"
+                },
+                "named": true,
+                "value": "dependent_name"
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
     "compound_literal_expression": {
       "type": "CHOICE",
@@ -16113,52 +16113,52 @@
       }
     },
     "qualified_field_identifier": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_scope_resolution"
-          },
-          {
-            "type": "FIELD",
-            "name": "name",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "dependent_field_identifier"
-                  },
-                  "named": true,
-                  "value": "dependent_name"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "qualified_field_identifier"
-                  },
-                  "named": true,
-                  "value": "qualified_identifier"
-                },
-                {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_scope_resolution"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "SYMBOL",
-                  "name": "template_method"
+                  "name": "dependent_field_identifier"
                 },
-                {
+                "named": true,
+                "value": "dependent_name"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "qualified_field_identifier"
+                },
+                "named": true,
+                "value": "qualified_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "template_method"
+              },
+              {
+                "type": "PREC_DYNAMIC",
+                "value": 1,
+                "content": {
                   "type": "SYMBOL",
                   "name": "_field_identifier"
                 }
-              ]
-            }
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
     "qualified_identifier": {
       "type": "SEQ",
@@ -16828,6 +16828,16 @@
     [
       "init_statement",
       "_for_statement_body"
+    ],
+    [
+      "field_expression",
+      "template_method",
+      "template_type"
+    ],
+    [
+      "qualified_field_identifier",
+      "template_method",
+      "template_type"
     ]
   ],
   "precedences": [

--- a/test/corpus/ambiguities.txt
+++ b/test/corpus/ambiguities.txt
@@ -5,6 +5,12 @@ template functions vs relational expressions
 T1 a = b < c > d;
 T2 e = f<T3>(g);
 int a = std::get<0>(t);
+if (x.y < z) break; // Not a template missing a '>'
+if (x.y < x->y && x.y > 50) break;
+if (x.foo < 0 || bar >= 1) break;
+if (x.Base::foo < 0 || bar >= 1) {
+  bool i = x.Base::foo < 0 || 1 > (5); // No way to tell
+}
 
 ---
 
@@ -34,7 +40,75 @@ int a = std::get<0>(t);
           (template_function
             (identifier)
             (template_argument_list (number_literal))))
-        (argument_list (identifier))))))
+        (argument_list (identifier)))))
+  (if_statement
+    (condition_clause
+      (binary_expression
+        (field_expression
+          (identifier)
+          (field_identifier))
+        (identifier)))
+    (break_statement))
+  (comment)
+  (if_statement
+    (condition_clause
+      (binary_expression
+        (binary_expression
+          (field_expression
+            (identifier)
+            (field_identifier))
+          (field_expression
+            (identifier)
+            (field_identifier)))
+        (binary_expression
+          (field_expression
+            (identifier)
+            (field_identifier))
+          (number_literal))))
+    (break_statement))
+  (if_statement
+    (condition_clause
+      (binary_expression
+        (binary_expression
+          (field_expression
+            (identifier)
+            (field_identifier))
+          (number_literal))
+        (binary_expression
+          (identifier)
+          (number_literal))))
+    (break_statement))
+  (if_statement
+    (condition_clause
+      (binary_expression
+        (binary_expression
+          (field_expression
+            (identifier)
+            (qualified_identifier
+              (namespace_identifier)
+              (field_identifier)))
+          (number_literal))
+        (binary_expression
+          (identifier)
+          (number_literal))))
+    (compound_statement
+      (declaration
+        (primitive_type)
+        (init_declarator
+          (identifier)
+          (binary_expression
+            (binary_expression
+              (field_expression
+                (identifier)
+                (qualified_identifier
+                  (namespace_identifier)
+                  (field_identifier)))
+              (number_literal))
+            (binary_expression
+              (number_literal)
+              (parenthesized_expression
+                (number_literal))))))
+    (comment))))
 
 =================================================
 function declarations vs variable initializations


### PR DESCRIPTION
This PR aims at fixing parsing of ambiguous expressions as mentioned in issue #231.

 Consider for example the following code:
```cpp
if (x.foo < 0 || bar >= 1)
    break;
```
This is currently recognized as an assignment ( of template method x.foo<...> to value 1) instead of the logical disjunction of two comparisons.
My understanding is that, for some reason, the prec.right in front of the field_expression's rule in the grammar prevents the parser from forking when "x.foo" is on the stack and forces the parsing of a template method instead.

I thus removed the prec.right annotation and added a conflict between field_expression, template_method and template_type.
In addition, I added a prec.dynamic annotation in front of field_identifier to avoid the reduction to a template method when reducing to a field_identifier is possible.

Note that there exists situation in which both interpretations could be valid, and there is no way to decide which one is correct from the information available to the parser.
An example of this situation is the following:
```cpp
// Either a call to X::foo<bool> with parameter 5, or a comparison of x.foo to 0 and bar to 5.
bool b = x.foo < 0 || bar > (5);
```

In this specific case, I think having a binary expression as a template parameter is very unusual and so the dynamic precedence is fine. However, I might have overlook other situations where the template_method interpretation is the correct one.

The same ambiguity appears when the field_identifier is qualified, I thus apply the same modifications to the qualified_field_identifier rule, i.e. removing the prec.right, adding a conflict and forcing the interpretation to a field_identifier using dynamic precedence in case of ambiguity).

Some things to consider before accepting this PR:
 - I am not sure about why prec.right were being used in the first place. Removing them might be a mistake. Maybe they should be moved to somewhere else instead of being removed.
 - I might have overlook other cases where the reduction to template_method is the correct choice.
 - I am not sure about the "value" to use for the dynamic precedence. I used 1 as a default. Should it be higher? Should the magic value be named?
 - I added two conflicts to the grammar [field_expression, template_method, template_type] and [qualified_field_identifier, template_method, template_type] when following indication from 'tree-sitter generate', but I am not sure about the meaning of these lists. Would having a single conflict with all non-terminals (i.e. [field_expression, qualified_field_identifier, template_method, template_type]) make any difference?

