### PR TITLE
C++ attribute fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -130,6 +130,13 @@ module.exports = grammar(C, {
       alias($.operator_cast_declaration, $.declaration),
     ),
 
+    // Attributes
+
+    attribute_declaration: $ => choice(
+      seq('[[', commaSep1($.attribute),']]'),
+      seq('[[', 'using', field('prefix', $.identifier), ':', commaSep1($.attribute), ']]')
+    ),
+
     // Types
 
     placeholder_type_specifier: $ => prec(1, seq(

--- a/grammar.js
+++ b/grammar.js
@@ -68,6 +68,8 @@ module.exports = grammar(C, {
     [$._block_item, $.statement],
 
     // C++
+    [$._declaration_modifiers, $.using_declaration],
+    [$._declaration_modifiers, $.attributed_statement, $.using_declaration],
     [$.template_function, $.template_type],
     [$.template_function, $.template_type, $.expression],
     [$.template_function, $.template_type, $.qualified_identifier],
@@ -752,7 +754,7 @@ module.exports = grammar(C, {
     )),
 
     using_declaration: $ => seq(
-      optional($.attribute_declaration),
+      repeat($.attribute_declaration),
       'using',
       optional(choice('namespace', 'enum')),
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -752,6 +752,7 @@ module.exports = grammar(C, {
     )),
 
     using_declaration: $ => seq(
+      optional($.attribute_declaration),
       'using',
       optional(choice('namespace', 'enum')),
       choice(

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -788,8 +788,12 @@ Attributes
 ================================================================================
 
 int f([[a::b(c), d]] int x) {}
+int f([[using a:b(c), d]] int x) {}
 
 [[gnu::always_inline]] [[gnu::hot]] [[gnu::const]] [[nodiscard]]
+inline int g();
+
+[[using gnu: always_inline, hot, visibility("default")]] [[gnu::const]] [[nodiscard]]
 inline int g();
 
 [[aaa]]
@@ -822,6 +826,23 @@ class A final : [[deprecated]] public B {};
           (primitive_type)
           (identifier))))
     (compound_statement))
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (attribute_declaration
+            (identifier)
+            (attribute
+              (identifier)
+              (argument_list
+                (identifier)))
+            (attribute
+              (identifier)))
+          (primitive_type)
+          (identifier))))
+    (compound_statement))
   (declaration
     (attribute_declaration
       (attribute
@@ -831,6 +852,30 @@ class A final : [[deprecated]] public B {};
       (attribute
         (identifier)
         (identifier)))
+    (attribute_declaration
+      (attribute
+        (identifier)
+        (identifier)))
+    (attribute_declaration
+      (attribute
+        (identifier)))
+    (storage_class_specifier)
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list)))
+  (declaration
+    (attribute_declaration
+      (identifier)
+      (attribute
+        (identifier))
+      (attribute
+        (identifier))
+      (attribute
+        (identifier)
+        (argument_list
+          (string_literal
+            (string_content)))))
     (attribute_declaration
       (attribute
         (identifier)

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -98,6 +98,7 @@ using ::e::f::g;
 using h = i::j;
 using namespace std;
 using enum Foo;
+[[deprecated]] using namespace std;
 
 template <typename T>
 using a = typename b<T>::c;
@@ -133,6 +134,11 @@ using foobar [[deprecated]] [[maybe_unused]] = int;
   (using_declaration
     (identifier))
   (using_declaration
+    (identifier))
+  (using_declaration
+    (attribute_declaration
+      (attribute
+        (identifier)))
     (identifier))
   (template_declaration
     (template_parameter_list

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -99,6 +99,7 @@ using h = i::j;
 using namespace std;
 using enum Foo;
 [[deprecated]] using namespace std;
+[[deprecated]] [[gnu::hot]] [[using gnu: const]] using namespace std;
 
 template <typename T>
 using a = typename b<T>::c;
@@ -137,6 +138,19 @@ using foobar [[deprecated]] [[maybe_unused]] = int;
     (identifier))
   (using_declaration
     (attribute_declaration
+      (attribute
+        (identifier)))
+    (identifier))
+  (using_declaration
+    (attribute_declaration
+      (attribute
+        (identifier)))
+    (attribute_declaration
+      (attribute
+        (identifier)
+        (identifier)))
+    (attribute_declaration
+      (identifier)
       (attribute
         (identifier)))
     (identifier))


### PR DESCRIPTION
Currently tree-sitter-cpp uses `attribute_declaration` from the C parser. Since the grammar for attributes is different between C and C++, this is not sufficient.

Namely C++ allows using `using` in attributes, ie:
```cpp
[[using gnu: always_inline, visibility("default")]]
inline int g();

//instead of
[[gnu::always_inline]] [[gnu::visibility("default")]]
inline int g();
```

Consequently tree-sitter-cpp currently errors with the above code. This patch fixes that, however it would also parse invalid attributes like `[[using gnu: gnu::hot]]` - please lmk if this is acceptable.

<br><br>

Additionally this patch also implements attributed [using-directives](https://en.cppreference.com/w/cpp/language/namespace#Using-directives) such as: 
```cpp
[[deprecated]] using namespace foo;
```
Currently, using-directives are parsed as `using_declaration`, consequently it now also accepts invalid [using-declaration](https://en.cppreference.com/w/cpp/language/using_declaration)s such as `[[deprecated]] using typename foo;` and invalid [using-enum-declaration](https://en.cppreference.com/w/cpp/language/enum#Using-enum-declaration)s such as `[[deprecated]] using enum foo;`. 

Please advise if pulling using-directives into their own `using_directive` node type is okay - that'd be more correct and alleviate this issue.