### PR TITLE
feat!: add support for reflection

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -887,6 +887,7 @@ module.exports = grammar(C, {
       $.co_return_statement,
       $.co_yield_statement,
       $.for_range_loop,
+      $.expansion_statement,
       $.try_statement,
       $.throw_statement,
     ),
@@ -896,6 +897,7 @@ module.exports = grammar(C, {
       $.co_return_statement,
       $.co_yield_statement,
       $.for_range_loop,
+      $.expansion_statement,
       $.try_statement,
       $.throw_statement,
     ),
@@ -1479,6 +1481,14 @@ module.exports = grammar(C, {
       $.splice_specifier,
       seq('template', $._splice_specialization_specifier),
     )),
+
+    expansion_statement: $ => seq(
+      'template', 'for',
+      '(',
+      $._for_range_loop_body,
+      ')',
+      field('body', $.statement),
+    ),
 
     operator_name: $ => prec(1, seq(
       'operator',

--- a/grammar.js
+++ b/grammar.js
@@ -206,6 +206,13 @@ module.exports = grammar(C, {
       ...original.members,
     ),
 
+    annotation: $ => seq('=', $.expression),
+
+    attribute_declaration: ($, original) => choice(
+      original,
+      seq('[[', commaSep1($.annotation), ']]'),
+    ),
+
     // When used in a trailing return type, these specifiers can now occur immediately before
     // a compound statement. This introduces a shift/reduce conflict that needs to be resolved
     // with an associativity.

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -92,6 +92,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "consteval_block_declaration"
+        },
+        {
+          "type": "SYMBOL",
           "name": "template_declaration"
         },
         {
@@ -225,6 +229,10 @@
         {
           "type": "SYMBOL",
           "name": "static_assert_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "consteval_block_declaration"
         },
         {
           "type": "SYMBOL",
@@ -3439,40 +3447,83 @@
       ]
     },
     "attribute_declaration": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "[["
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "[["
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "attribute"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "attribute"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]]"
+            }
+          ]
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "attribute"
+              "type": "STRING",
+              "value": "[["
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "attribute"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "annotation"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "annotation"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]]"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": "]]"
         }
       ]
     },
@@ -5007,6 +5058,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "splice_type_specifier"
+        },
+        {
+          "type": "SYMBOL",
           "name": "placeholder_type_specifier"
         },
         {
@@ -5705,6 +5760,10 @@
           "name": "static_assert_declaration"
         },
         {
+          "type": "SYMBOL",
+          "name": "consteval_block_declaration"
+        },
+        {
           "type": "STRING",
           "value": ";"
         }
@@ -6314,6 +6373,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "expansion_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "try_statement"
         },
         {
@@ -6402,6 +6465,10 @@
         {
           "type": "SYMBOL",
           "name": "for_range_loop"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expansion_statement"
         },
         {
           "type": "SYMBOL",
@@ -7202,6 +7269,14 @@
         {
           "type": "SYMBOL",
           "name": "fold_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "reflect_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "splice_expression"
         }
       ]
     },
@@ -8846,20 +8921,71 @@
       }
     },
     "call_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC",
-          "value": 15,
-          "content": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PREC",
+            "value": 15,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "function",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "arguments",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "argument_list"
+                  }
+                }
+              ]
+            }
+          },
+          {
             "type": "SEQ",
             "members": [
               {
                 "type": "FIELD",
                 "name": "function",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "primitive_type"
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "typename"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "splice_type_specifier"
+                        }
+                      ]
+                    }
+                  ]
                 }
               },
               {
@@ -8872,29 +8998,8 @@
               }
             ]
           }
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "function",
-              "content": {
-                "type": "SYMBOL",
-                "name": "primitive_type"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "arguments",
-              "content": {
-                "type": "SYMBOL",
-                "name": "argument_list"
-              }
-            }
-          ]
-        }
-      ]
+        ]
+      }
     },
     "gnu_asm_expression": {
       "type": "PREC",
@@ -9530,6 +9635,10 @@
               {
                 "type": "SYMBOL",
                 "name": "operator_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "splice_expression"
               }
             ]
           }
@@ -9584,6 +9693,27 @@
                   {
                     "type": "SYMBOL",
                     "name": "primitive_type"
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "typename"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "splice_type_specifier"
+                      }
+                    ]
                   }
                 ]
               }
@@ -11201,6 +11331,19 @@
         }
       ]
     },
+    "annotation": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        }
+      ]
+    },
     "_class_declaration": {
       "type": "SEQ",
       "members": [
@@ -11358,6 +11501,10 @@
           {
             "type": "SYMBOL",
             "name": "template_type"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "splice_type_specifier"
           },
           {
             "type": "ALIAS",
@@ -13851,6 +13998,10 @@
             {
               "type": "SYMBOL",
               "name": "nested_namespace_specifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "splice_specifier"
             }
           ]
         },
@@ -13964,6 +14115,10 @@
             {
               "type": "SYMBOL",
               "name": "qualified_identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "splice_type_specifier"
             }
           ]
         },
@@ -14064,6 +14219,23 @@
         {
           "type": "STRING",
           "value": ";"
+        }
+      ]
+    },
+    "consteval_block_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "consteval"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "compound_statement"
+          }
         }
       ]
     },
@@ -16852,6 +17024,14 @@
                       "name": "decltype"
                     },
                     {
+                      "type": "SYMBOL",
+                      "name": "splice_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "splice_type_specifier"
+                    },
+                    {
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
@@ -16912,7 +17092,7 @@
               },
               {
                 "type": "PREC_DYNAMIC",
-                "value": 1,
+                "value": 2,
                 "content": {
                   "type": "SYMBOL",
                   "name": "_field_identifier"
@@ -16954,25 +17134,29 @@
                 "name": "template_function"
               },
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "template"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                ]
+                "type": "PREC_DYNAMIC",
+                "value": 1,
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "template"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
               },
               {
                 "type": "SYMBOL",
@@ -17027,8 +17211,12 @@
                 "name": "template_type"
               },
               {
-                "type": "SYMBOL",
-                "name": "_type_identifier"
+                "type": "PREC_DYNAMIC",
+                "value": 1,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_type_identifier"
+                }
               }
             ]
           }
@@ -17157,6 +17345,142 @@
                 "name": "initializer_list"
               }
             ]
+          }
+        }
+      ]
+    },
+    "reflect_expression": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "^^"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "::"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "type_descriptor"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "splice_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "[:"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ":]"
+        }
+      ]
+    },
+    "_splice_specialization_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "splice_specifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_argument_list"
+        }
+      ]
+    },
+    "splice_type_specifier": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "splice_specifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_splice_specialization_specifier"
+          }
+        ]
+      }
+    },
+    "splice_expression": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "splice_specifier"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "template"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_splice_specialization_specifier"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "expansion_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "STRING",
+          "value": "for"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_for_range_loop_body"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "statement"
           }
         }
       ]
@@ -17538,6 +17862,12 @@
       "qualified_identifier"
     ],
     [
+      "template_function",
+      "template_type",
+      "qualified_identifier",
+      "qualified_type_identifier"
+    ],
+    [
       "template_type",
       "qualified_type_identifier"
     ],
@@ -17631,6 +17961,16 @@
       "qualified_field_identifier",
       "template_method",
       "template_type"
+    ],
+    [
+      "type_specifier",
+      "template_type",
+      "template_function",
+      "expression"
+    ],
+    [
+      "splice_type_specifier",
+      "splice_expression"
     ]
   ],
   "precedences": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -276,6 +276,10 @@
         "named": true
       },
       {
+        "type": "reflect_expression",
+        "named": true
+      },
+      {
         "type": "requires_clause",
         "named": true
       },
@@ -285,6 +289,10 @@
       },
       {
         "type": "sizeof_expression",
+        "named": true
+      },
+      {
+        "type": "splice_expression",
         "named": true
       },
       {
@@ -355,6 +363,10 @@
       },
       {
         "type": "do_statement",
+        "named": true
+      },
+      {
+        "type": "expansion_statement",
         "named": true
       },
       {
@@ -445,6 +457,10 @@
       },
       {
         "type": "sized_type_specifier",
+        "named": true
+      },
+      {
+        "type": "splice_type_specifier",
         "named": true
       },
       {
@@ -718,6 +734,21 @@
     }
   },
   {
+    "type": "annotation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "argument_list",
     "named": true,
     "fields": {},
@@ -939,6 +970,10 @@
       "required": true,
       "types": [
         {
+          "type": "annotation",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         }
@@ -1024,6 +1059,10 @@
         },
         {
           "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "splice_type_specifier",
           "named": true
         },
         {
@@ -1212,7 +1251,7 @@
         ]
       },
       "function": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -1222,6 +1261,14 @@
           {
             "type": "primitive_type",
             "named": true
+          },
+          {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
+            "type": "typename",
+            "named": false
           }
         ]
       }
@@ -1276,6 +1323,10 @@
         },
         {
           "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expansion_statement",
           "named": true
         },
         {
@@ -1431,6 +1482,10 @@
             "named": true
           },
           {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           },
@@ -1563,7 +1618,7 @@
     "named": true,
     "fields": {
       "type": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -1572,6 +1627,10 @@
           },
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -1585,6 +1644,10 @@
           {
             "type": "type_identifier",
             "named": true
+          },
+          {
+            "type": "typename",
+            "named": false
           }
         ]
       },
@@ -1633,6 +1696,10 @@
         },
         {
           "type": "concept_definition",
+          "named": true
+        },
+        {
+          "type": "consteval_block_declaration",
           "named": true
         },
         {
@@ -1834,6 +1901,22 @@
     }
   },
   {
+    "type": "consteval_block_declaration",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "compound_statement",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "constraint_conjunction",
     "named": true,
     "fields": {
@@ -1859,6 +1942,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -1910,6 +1997,10 @@
             "named": true
           },
           {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           },
@@ -1947,6 +2038,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -1995,6 +2090,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -2124,6 +2223,10 @@
         },
         {
           "type": "concept_definition",
+          "named": true
+        },
+        {
+          "type": "consteval_block_declaration",
           "named": true
         },
         {
@@ -2384,6 +2487,10 @@
             "named": true
           },
           {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           },
@@ -2459,6 +2566,92 @@
     }
   },
   {
+    "type": "expansion_statement",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "statement",
+            "named": true
+          }
+        ]
+      },
+      "declarator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_declarator",
+            "named": true
+          }
+        ]
+      },
+      "initializer": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "init_statement",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          },
+          {
+            "type": "initializer_list",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_specifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
+          "named": true
+        },
+        {
+          "type": "storage_class_specifier",
+          "named": true
+        },
+        {
+          "type": "type_qualifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "explicit_function_specifier",
     "named": true,
     "fields": {},
@@ -2506,6 +2699,10 @@
         },
         {
           "type": "concept_definition",
+          "named": true
+        },
+        {
+          "type": "consteval_block_declaration",
           "named": true
         },
         {
@@ -2704,6 +2901,10 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
@@ -2809,6 +3010,10 @@
           },
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_expression",
             "named": true
           },
           {
@@ -3241,6 +3446,10 @@
         },
         {
           "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "splice_type_specifier",
           "named": true
         },
         {
@@ -4307,6 +4516,10 @@
         {
           "type": "nested_namespace_specifier",
           "named": true
+        },
+        {
+          "type": "splice_specifier",
+          "named": true
         }
       ]
     }
@@ -5097,6 +5310,10 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
@@ -5233,6 +5450,10 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
@@ -5337,6 +5558,10 @@
         },
         {
           "type": "concept_definition",
+          "named": true
+        },
+        {
+          "type": "consteval_block_declaration",
           "named": true
         },
         {
@@ -5540,6 +5765,10 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
@@ -5673,6 +5902,10 @@
         },
         {
           "type": "concept_definition",
+          "named": true
+        },
+        {
+          "type": "consteval_block_declaration",
           "named": true
         },
         {
@@ -5894,6 +6127,14 @@
             "named": true
           },
           {
+            "type": "splice_expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           }
@@ -5964,6 +6205,25 @@
     }
   },
   {
+    "type": "reflect_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "type_descriptor",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "requirement_seq",
     "named": true,
     "fields": {},
@@ -6012,6 +6272,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -6228,6 +6492,59 @@
     }
   },
   {
+    "type": "splice_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "splice_specifier",
+          "named": true
+        },
+        {
+          "type": "template_argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "splice_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "splice_type_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "splice_specifier",
+          "named": true
+        },
+        {
+          "type": "template_argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "static_assert_declaration",
     "named": true,
     "fields": {
@@ -6305,6 +6622,10 @@
         "types": [
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -6843,6 +7164,10 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "continue_statement",
           "named": true
         },
@@ -6852,6 +7177,10 @@
         },
         {
           "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expansion_statement",
           "named": true
         },
         {
@@ -7134,6 +7463,10 @@
           "named": true
         },
         {
+          "type": "splice_type_specifier",
+          "named": true
+        },
+        {
           "type": "template_type",
           "named": true
         },
@@ -7214,6 +7547,10 @@
         "types": [
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -7341,6 +7678,10 @@
         },
         {
           "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "splice_type_specifier",
           "named": true
         }
       ]
@@ -7632,6 +7973,10 @@
     "named": false
   },
   {
+    "type": ":]",
+    "named": false
+  },
+  {
     "type": ";",
     "named": false
   },
@@ -7720,6 +8065,10 @@
     "named": false
   },
   {
+    "type": "[:",
+    "named": false
+  },
+  {
     "type": "[[",
     "named": false
   },
@@ -7741,6 +8090,10 @@
   },
   {
     "type": "^=",
+    "named": false
+  },
+  {
+    "type": "^^",
     "named": false
   },
   {

--- a/test/corpus/reflection.txt
+++ b/test/corpus/reflection.txt
@@ -836,3 +836,100 @@ consteval { TCls<void>::sfn(); }
                   (primitive_type))))
             (identifier))
           (argument_list))))))
+
+================================================================================
+Annotations
+================================================================================
+
+[[=1]] void f();
+[[=2, =3]] void g();
+void g [[=4]] [[=2]] ();
+
+template <class T>
+[[=T::type()]] void f(T t);
+
+struct Option { bool value; };
+struct C {
+    [[=Option{true}]] int a;
+    [[=Option{false}]] int b;
+};
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (attribute_declaration
+      (annotation
+        (number_literal)))
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list)))
+  (declaration
+    (attribute_declaration
+      (annotation
+        (number_literal))
+      (annotation
+        (number_literal)))
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list)))
+  (declaration
+    (primitive_type)
+    (function_declarator
+      (attributed_declarator
+        (identifier)
+        (attribute_declaration
+          (annotation
+            (number_literal)))
+        (attribute_declaration
+          (annotation
+            (number_literal))))
+      (parameter_list)))
+  (template_declaration
+    (template_parameter_list
+      (type_parameter_declaration
+        (type_identifier)))
+    (declaration
+      (attribute_declaration
+        (annotation
+          (call_expression
+            (qualified_identifier
+              (namespace_identifier)
+              (identifier))
+            (argument_list))))
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list
+          (parameter_declaration
+            (type_identifier)
+            (identifier))))))
+  (struct_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (primitive_type)
+        (field_identifier))))
+  (struct_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (attribute_declaration
+          (annotation
+            (compound_literal_expression
+              (type_identifier)
+              (initializer_list
+                (true)))))
+        (primitive_type)
+        (field_identifier))
+      (field_declaration
+        (attribute_declaration
+          (annotation
+            (compound_literal_expression
+              (type_identifier)
+              (initializer_list
+                (false)))))
+        (primitive_type)
+        (field_identifier)))))

--- a/test/corpus/reflection.txt
+++ b/test/corpus/reflection.txt
@@ -1,0 +1,838 @@
+================================================================================
+Reflection operator
+================================================================================
+static_assert(std::meta::is_type(^^int()));
+static_assert(std::meta::is_namespace(^^::));
+
+template<bool> struct X {};
+consteval bool operator<(std::meta::info, X<false>) { return false; }
+consteval void g(std::meta::info r, X<false> xv) {
+  r == (^^int) && true;
+  (^^X) < xv;
+  ^^X<true> < xv;
+}
+
+constexpr std::meta::info r1 = ^^A;
+constexpr std::meta::info r2 = ^^B::C;
+
+template <typename T> void fn() requires (^^T == ^^int);
+
+constexpr std::meta::info a = ^^fn<char>;
+constexpr std::meta::info b = ^^std::vector;
+
+template <typename T>
+struct S {
+  static constexpr std::meta::info r = ^^T;
+  using type = T;
+};
+static_assert(S<int>::r == ^^int);
+static_assert(^^S<int>::type != ^^int);
+
+constexpr T obj{.r=^^::};
+
+constexpr std::meta::info yeti = ^^void(int) const &;
+add_member(^^char const *);
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (static_assert_declaration
+    (call_expression
+      (qualified_identifier
+        (namespace_identifier)
+        (qualified_identifier
+          (namespace_identifier)
+          (identifier)))
+      (argument_list
+        (reflect_expression
+          (call_expression
+            (primitive_type)
+            (argument_list))))))
+  (static_assert_declaration
+    (call_expression
+      (qualified_identifier
+        (namespace_identifier)
+        (qualified_identifier
+          (namespace_identifier)
+          (identifier)))
+      (argument_list
+        (reflect_expression))))
+  (template_declaration
+    (template_parameter_list
+      (parameter_declaration
+        (primitive_type)))
+    (struct_specifier
+      (type_identifier)
+      (field_declaration_list)))
+  (function_definition
+    (type_qualifier)
+    (primitive_type)
+    (function_declarator
+      (operator_name)
+      (parameter_list
+        (parameter_declaration
+          (qualified_identifier
+            (namespace_identifier)
+            (qualified_identifier
+              (namespace_identifier)
+              (type_identifier))))
+        (parameter_declaration
+          (template_type
+            (type_identifier)
+            (template_argument_list
+              (false))))))
+    (compound_statement
+      (return_statement
+        (false))))
+  (function_definition
+    (type_qualifier)
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (qualified_identifier
+            (namespace_identifier)
+            (qualified_identifier
+              (namespace_identifier)
+              (type_identifier)))
+          (identifier))
+        (parameter_declaration
+          (template_type
+            (type_identifier)
+            (template_argument_list
+              (false)))
+          (identifier))))
+    (compound_statement
+      (expression_statement
+        (binary_expression
+          (binary_expression
+            (identifier)
+            (parenthesized_expression
+              (reflect_expression
+                (type_descriptor
+                  (primitive_type)))))
+          (true)))
+      (expression_statement
+        (binary_expression
+          (parenthesized_expression
+            (reflect_expression
+              (identifier)))
+          (identifier)))
+      (expression_statement
+        (binary_expression
+          (reflect_expression
+            (type_descriptor
+              (template_type
+                (type_identifier)
+                (template_argument_list
+                  (true)))))
+          (identifier)))))
+  (declaration
+    (type_qualifier)
+    (qualified_identifier
+      (namespace_identifier)
+      (qualified_identifier
+        (namespace_identifier)
+        (type_identifier)))
+    (init_declarator
+      (identifier)
+      (reflect_expression
+        (identifier))))
+  (declaration
+    (type_qualifier)
+    (qualified_identifier
+      (namespace_identifier)
+      (qualified_identifier
+        (namespace_identifier)
+        (type_identifier)))
+    (init_declarator
+      (identifier)
+      (reflect_expression
+        (type_descriptor
+          (qualified_identifier
+            (namespace_identifier)
+            (type_identifier))))))
+  (template_declaration
+    (template_parameter_list
+      (type_parameter_declaration
+        (type_identifier)))
+    (declaration
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list)
+        (requires_clause
+          (binary_expression
+            (reflect_expression
+              (type_descriptor
+                (type_identifier)))
+            (reflect_expression
+              (type_descriptor
+                (primitive_type))))))))
+  (declaration
+    (type_qualifier)
+    (qualified_identifier
+      (namespace_identifier)
+      (qualified_identifier
+        (namespace_identifier)
+        (type_identifier)))
+    (init_declarator
+      (identifier)
+      (reflect_expression
+        (template_function
+          (identifier)
+          (template_argument_list
+            (type_descriptor
+              (primitive_type)))))))
+  (declaration
+    (type_qualifier)
+    (qualified_identifier
+      (namespace_identifier)
+      (qualified_identifier
+        (namespace_identifier)
+        (type_identifier)))
+    (init_declarator
+      (identifier)
+      (reflect_expression
+        (type_descriptor
+          (qualified_identifier
+            (namespace_identifier)
+            (type_identifier))))))
+  (template_declaration
+    (template_parameter_list
+      (type_parameter_declaration
+        (type_identifier)))
+    (struct_specifier
+      (type_identifier)
+      (field_declaration_list
+        (field_declaration
+          (storage_class_specifier)
+          (type_qualifier)
+          (qualified_identifier
+            (namespace_identifier)
+            (qualified_identifier
+              (namespace_identifier)
+              (type_identifier)))
+          (field_identifier)
+          (reflect_expression
+            (identifier)))
+        (alias_declaration
+          (type_identifier)
+          (type_descriptor
+            (type_identifier))))))
+  (static_assert_declaration
+    (binary_expression
+      (qualified_identifier
+        (template_type
+          (type_identifier)
+          (template_argument_list
+            (type_descriptor
+              (primitive_type))))
+        (identifier))
+      (reflect_expression
+        (type_descriptor
+          (primitive_type)))))
+  (static_assert_declaration
+    (binary_expression
+      (reflect_expression
+        (type_descriptor
+          (qualified_identifier
+            (template_type
+              (type_identifier)
+              (template_argument_list
+                (type_descriptor
+                  (primitive_type))))
+            (type_identifier))))
+      (reflect_expression
+        (type_descriptor
+          (primitive_type)))))
+  (declaration
+    (type_qualifier)
+    (type_identifier)
+    (init_declarator
+      (identifier)
+      (initializer_list
+        (initializer_pair
+          (field_designator
+            (field_identifier))
+          (reflect_expression)))))
+  (declaration
+    (type_qualifier)
+    (qualified_identifier
+      (namespace_identifier)
+      (qualified_identifier
+        (namespace_identifier)
+        (type_identifier)))
+    (init_declarator
+      (identifier)
+      (reflect_expression
+        (type_descriptor
+          (primitive_type)
+          (abstract_function_declarator
+            (parameter_list
+              (parameter_declaration
+                (primitive_type)))
+            (type_qualifier)
+            (ref_qualifier))))))
+  (expression_statement
+    (call_expression
+      (identifier)
+      (argument_list
+        (reflect_expression
+          (type_descriptor
+            (primitive_type)
+            (type_qualifier)
+            (abstract_pointer_declarator)))))))
+
+
+================================================================================
+Splice type specifiers and requirements
+================================================================================
+
+using alias = [:^^TCls:]<([:^^v:])>;
+using enum [:^^Enum:];
+using namespace [:^^:::];
+namespace global = [:^^:::];
+
+int o1 = [:^^S::x:];
+auto o2 = typename [:^^TCls:]<([:^^v:])>();
+int S::*k = &[:^^S::m:];
+int v1 = [:^^TCls<1>:]::s;
+int v2 = template [:^^TCls:]<2>::s;
+typename [:^^TCls:]<3>::type v3 = 3;
+template [:^^TCls:]<3>::type v4 = 4;
+typename template [:^^TCls:]<3>::type v5 = 5;
+
+template <typename T>
+concept C = requires {
+  typename [:T::r1:];
+  typename [:T::r2:]<int>;
+};
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (alias_declaration
+    (type_identifier)
+    (type_descriptor
+      (splice_type_specifier
+        (splice_specifier
+          (reflect_expression
+            (identifier)))
+        (template_argument_list
+          (parenthesized_expression
+            (splice_expression
+              (splice_specifier
+                (reflect_expression
+                  (identifier)))))))))
+  (using_declaration
+    (splice_type_specifier
+      (splice_specifier
+        (reflect_expression
+          (identifier)))))
+  (using_declaration
+    (splice_type_specifier
+      (splice_specifier
+        (reflect_expression))))
+  (namespace_alias_definition
+    (namespace_identifier)
+    (splice_specifier
+      (reflect_expression)))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (splice_expression
+        (splice_specifier
+          (reflect_expression
+            (type_descriptor
+              (qualified_identifier
+                (namespace_identifier)
+                (type_identifier))))))))
+  (declaration
+    (placeholder_type_specifier
+      (auto))
+    (init_declarator
+      (identifier)
+      (call_expression
+        (splice_type_specifier
+          (splice_specifier
+            (reflect_expression
+              (identifier)))
+          (template_argument_list
+            (parenthesized_expression
+              (splice_expression
+                (splice_specifier
+                  (reflect_expression
+                    (identifier)))))))
+        (argument_list))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (qualified_identifier
+        (namespace_identifier)
+        (pointer_type_declarator
+          (type_identifier)))
+      (pointer_expression
+        (splice_expression
+          (splice_specifier
+            (reflect_expression
+              (type_descriptor
+                (qualified_identifier
+                  (namespace_identifier)
+                  (type_identifier)))))))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (qualified_identifier
+        (splice_type_specifier
+          (splice_specifier
+            (reflect_expression
+              (template_function
+                (identifier)
+                (template_argument_list
+                  (number_literal))))))
+        (identifier))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (qualified_identifier
+        (splice_expression
+          (splice_specifier
+            (reflect_expression
+              (identifier)))
+          (template_argument_list
+            (number_literal)))
+        (identifier))))
+  (declaration
+    (dependent_type
+      (qualified_identifier
+        (splice_type_specifier
+          (splice_specifier
+            (reflect_expression
+              (identifier)))
+          (template_argument_list
+            (number_literal)))
+        (type_identifier)))
+    (init_declarator
+      (identifier)
+      (number_literal)))
+  (declaration
+    (qualified_identifier
+      (splice_expression
+        (splice_specifier
+          (reflect_expression
+            (identifier)))
+        (template_argument_list
+          (number_literal)))
+      (type_identifier))
+    (init_declarator
+      (identifier)
+      (number_literal)))
+  (declaration
+    (dependent_type
+      (qualified_identifier
+        (splice_expression
+          (splice_specifier
+            (reflect_expression
+              (identifier)))
+          (template_argument_list
+            (number_literal)))
+        (type_identifier)))
+    (init_declarator
+      (identifier)
+      (number_literal)))
+  (template_declaration
+    (template_parameter_list
+      (type_parameter_declaration
+        (type_identifier)))
+    (concept_definition
+      (identifier)
+      (requires_expression
+        (requirement_seq
+          (type_requirement
+            (splice_type_specifier
+              (splice_specifier
+                (qualified_identifier
+                  (namespace_identifier)
+                  (identifier)))))
+          (simple_requirement)
+          (type_requirement
+            (splice_type_specifier
+              (splice_specifier
+                (qualified_identifier
+                  (namespace_identifier)
+                  (identifier)))
+              (template_argument_list
+                (type_descriptor
+                  (primitive_type)))))
+          (simple_requirement))))))
+
+================================================================================
+Splice expressions
+================================================================================
+
+constexpr int c = [:^^S:]::a;
+
+constexpr int d = template [:^^TCls:]<int>::b;
+
+template <auto V> constexpr int e = [:V:];
+constexpr int f = template [:^^e:]<^^S::a>;
+
+constexpr auto g = typename [:^^int:](42);
+constexpr auto h = typename [:^^int:]{42};
+constexpr auto j = e<([:^^h:])>;
+
+[:^^A::f:](3, 4);
+T* p4 = template [:r:]<200>();
+S<[:r:] + 1> s3;
+
+template <auto T, auto NS>
+void fn() {
+  using a = [:T:]<1>;
+  static_assert([:NS:]::template TCls<1>::v == a::v);
+}
+
+fn<^^N::TCls, ^^N>();
+
+int v1 = base_.[:fields[I]:];
+int v2 = base_->[:fields[I]:];
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (type_qualifier)
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (qualified_identifier
+        (splice_type_specifier
+          (splice_specifier
+            (reflect_expression
+              (identifier))))
+        (identifier))))
+  (declaration
+    (type_qualifier)
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (qualified_identifier
+        (splice_expression
+          (splice_specifier
+            (reflect_expression
+              (identifier)))
+          (template_argument_list
+            (type_descriptor
+              (primitive_type))))
+        (identifier))))
+  (template_declaration
+    (template_parameter_list
+      (parameter_declaration
+        (placeholder_type_specifier
+          (auto))
+        (identifier)))
+    (declaration
+      (type_qualifier)
+      (primitive_type)
+      (init_declarator
+        (identifier)
+        (splice_expression
+          (splice_specifier
+            (identifier))))))
+  (declaration
+    (type_qualifier)
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (splice_expression
+        (splice_specifier
+          (reflect_expression
+            (identifier)))
+        (template_argument_list
+          (reflect_expression
+            (type_descriptor
+              (qualified_identifier
+                (namespace_identifier)
+                (type_identifier))))))))
+  (declaration
+    (type_qualifier)
+    (placeholder_type_specifier
+      (auto))
+    (init_declarator
+      (identifier)
+      (call_expression
+        (splice_type_specifier
+          (splice_specifier
+            (reflect_expression
+              (type_descriptor
+                (primitive_type)))))
+        (argument_list
+          (number_literal)))))
+  (declaration
+    (type_qualifier)
+    (placeholder_type_specifier
+      (auto))
+    (init_declarator
+      (identifier)
+      (compound_literal_expression
+        (splice_type_specifier
+          (splice_specifier
+            (reflect_expression
+              (type_descriptor
+                (primitive_type)))))
+        (initializer_list
+          (number_literal)))))
+  (declaration
+    (type_qualifier)
+    (placeholder_type_specifier
+      (auto))
+    (init_declarator
+      (identifier)
+      (template_function
+        (identifier)
+        (template_argument_list
+          (parenthesized_expression
+            (splice_expression
+              (splice_specifier
+                (reflect_expression
+                  (identifier)))))))))
+  (expression_statement
+    (call_expression
+      (splice_expression
+        (splice_specifier
+          (reflect_expression
+            (type_descriptor
+              (qualified_identifier
+                (namespace_identifier)
+                (type_identifier))))))
+      (argument_list
+        (number_literal)
+        (number_literal))))
+  (declaration
+    (type_identifier)
+    (init_declarator
+      (pointer_declarator
+        (identifier))
+      (call_expression
+        (splice_expression
+          (splice_specifier
+            (identifier))
+          (template_argument_list
+            (number_literal)))
+        (argument_list))))
+  (declaration
+    (template_type
+      (type_identifier)
+      (template_argument_list
+        (binary_expression
+          (splice_expression
+            (splice_specifier
+              (identifier)))
+          (number_literal))))
+    (identifier))
+  (template_declaration
+    (template_parameter_list
+      (parameter_declaration
+        (placeholder_type_specifier
+          (auto))
+        (identifier))
+      (parameter_declaration
+        (placeholder_type_specifier
+          (auto))
+        (identifier)))
+    (function_definition
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list))
+      (compound_statement
+        (alias_declaration
+          (type_identifier)
+          (type_descriptor
+            (splice_type_specifier
+              (splice_specifier
+                (identifier))
+              (template_argument_list
+                (number_literal)))))
+        (static_assert_declaration
+          (binary_expression
+            (binary_expression
+              (binary_expression
+                (qualified_identifier
+                  (splice_type_specifier
+                    (splice_specifier
+                      (identifier)))
+                  (identifier))
+                (number_literal))
+              (qualified_identifier
+                (identifier)))
+            (qualified_identifier
+              (namespace_identifier)
+              (identifier)))))))
+  (expression_statement
+    (call_expression
+      (template_function
+        (identifier)
+        (template_argument_list
+          (reflect_expression
+            (type_descriptor
+              (qualified_identifier
+                (namespace_identifier)
+                (type_identifier))))
+          (reflect_expression
+            (identifier))))
+      (argument_list)))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (field_expression
+        (identifier)
+        (splice_expression
+          (splice_specifier
+            (subscript_expression
+              (identifier)
+              (subscript_argument_list
+                (identifier))))))))
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (field_expression
+        (identifier)
+        (splice_expression
+          (splice_specifier
+            (subscript_expression
+              (identifier)
+              (subscript_argument_list
+                (identifier)))))))))
+
+================================================================================
+Consteval blocks
+================================================================================
+class A {
+  struct A;
+  consteval {
+    std::meta::define_aggregate(^^S, {});
+    return;
+  }
+};
+
+template <std::meta::info R> consteval void tfn2() {
+  consteval { std::meta::define_aggregate(R, {}); }
+}
+
+template <typename> struct TCls {
+  static constexpr void sfn() requires ([] {
+    struct S4;
+    consteval { std::meta::define_aggregate(^^S4, {}); }
+    return true;
+  }()) { }
+};
+
+consteval { TCls<void>::sfn(); }
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (class_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (struct_specifier
+          (type_identifier)))
+      (consteval_block_declaration
+        (compound_statement
+          (expression_statement
+            (call_expression
+              (qualified_identifier
+                (namespace_identifier)
+                (qualified_identifier
+                  (namespace_identifier)
+                  (identifier)))
+              (argument_list
+                (reflect_expression
+                  (identifier))
+                (initializer_list))))
+          (return_statement)))))
+  (template_declaration
+    (template_parameter_list
+      (parameter_declaration
+        (qualified_identifier
+          (namespace_identifier)
+          (qualified_identifier
+            (namespace_identifier)
+            (type_identifier)))
+        (identifier)))
+    (function_definition
+      (type_qualifier)
+      (primitive_type)
+      (function_declarator
+        (identifier)
+        (parameter_list))
+      (compound_statement
+        (consteval_block_declaration
+          (compound_statement
+            (expression_statement
+              (call_expression
+                (qualified_identifier
+                  (namespace_identifier)
+                  (qualified_identifier
+                    (namespace_identifier)
+                    (identifier)))
+                (argument_list
+                  (identifier)
+                  (initializer_list)))))))))
+  (template_declaration
+    (template_parameter_list
+      (type_parameter_declaration))
+    (struct_specifier
+      (type_identifier)
+      (field_declaration_list
+        (function_definition
+          (storage_class_specifier)
+          (type_qualifier)
+          (primitive_type)
+          (function_declarator
+            (field_identifier)
+            (parameter_list)
+            (requires_clause
+              (call_expression
+                (lambda_expression
+                  (lambda_capture_specifier)
+                  (compound_statement
+                    (struct_specifier
+                      (type_identifier))
+                    (consteval_block_declaration
+                      (compound_statement
+                        (expression_statement
+                          (call_expression
+                            (qualified_identifier
+                              (namespace_identifier)
+                              (qualified_identifier
+                                (namespace_identifier)
+                                (identifier)))
+                            (argument_list
+                              (reflect_expression
+                                (identifier))
+                              (initializer_list))))))
+                    (return_statement
+                      (true))))
+                (argument_list))))
+          (compound_statement)))))
+  (consteval_block_declaration
+    (compound_statement
+      (expression_statement
+        (call_expression
+          (qualified_identifier
+            (template_type
+              (type_identifier)
+              (template_argument_list
+                (type_descriptor
+                  (primitive_type))))
+            (identifier))
+          (argument_list))))))

--- a/test/corpus/reflection.txt
+++ b/test/corpus/reflection.txt
@@ -933,3 +933,39 @@ struct C {
                 (false)))))
         (primitive_type)
         (field_identifier)))))
+
+================================================================================
+Expansion statements
+================================================================================
+
+template for (auto const& c : {Containers...}) {}
+template for (constexpr int I : std::views::iota(0zu, sizeof...(Ts))) {}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expansion_statement
+    (placeholder_type_specifier
+      (auto))
+    (type_qualifier)
+    (reference_declarator
+      (identifier))
+    (initializer_list
+      (parameter_pack_expansion
+        (identifier)))
+    (compound_statement))
+  (expansion_statement
+    (type_qualifier)
+    (primitive_type)
+    (identifier)
+    (call_expression
+      (qualified_identifier
+        (namespace_identifier)
+        (qualified_identifier
+          (namespace_identifier)
+          (identifier)))
+      (argument_list
+        (number_literal)
+        (sizeof_expression
+          (identifier))))
+    (compound_statement)))


### PR DESCRIPTION
Three commits here for three really huge c++26 features. Included corpus tests that pull most of the examples from the ISO papers themselves.

## [P2996: reflection](https://isocpp.org/files/papers/P2996R13.html)
This adds support for all the language changes introduced in P2996 which
was recently voted into the upcoming c++26 standard.

This includes:
- reflection expressions: the reflect operator (`^^`) followed by
  expressions, type descriptors, or the global namespace (`::`)
- splice specifiers/expressions: `[: expression :]`, which can appear as a
  type, expression, alias descriptor, and more.
- `consteval` blocks: similar to static_asserts but have been introduced
  specifically to allow constant evaluation side effects to occur at
  specific places in code

## [P3394: annotations](https://isocpp.org/files/papers/P3394R4.html)

Related to reflection, annotations use the same syntax as attributes,
but begin with an `=` and support any constant expression. Annotations
and Attributes can't be mixed within [[ ... ]].

## [P1306: expansion statements](https://isocpp.org/files/papers/P1306R5.html)

Introduces support for `template for ( init; for-range-decl : expansion-init )`
which is a compile-time way to expand (iterate over):
  - expansion expressions
  - anything destructurable via structured bindings
  - ranges with compile time size

It was sufficient to simply re-use the existing rule for
_for_range_loop_body for the part inside the parentheses, but add the
required sequence of `template` followed by `for`