### PR TITLE
Add support for C++26 class-property-specifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -227,7 +227,7 @@ module.exports = grammar(C, {
         field('name', $._class_name),
         seq(
           optional(field('name', $._class_name)),
-          optional($.virtual_specifier),
+          optional(repeat($.class_property_specifier)),
           optional($.base_class_clause),
           field('body', $.field_declaration_list),
         ),
@@ -235,6 +235,12 @@ module.exports = grammar(C, {
       optional($.attribute_specifier),
     )),
 
+    class_property_specifier: $ => choice(
+      'final',
+      'trivially_relocatable_if_eligible',
+      'replaceable_if_eligible',
+    ),
+ 
     class_specifier: $ => seq(
       'class',
       $._class_declaration,

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -651,14 +651,14 @@ struct D final {};
 (translation_unit
   (class_specifier
     (type_identifier)
-    (virtual_specifier)
+    (class_property_specifier)
     (base_class_clause
       (access_specifier)
       (type_identifier))
     (field_declaration_list))
   (class_specifier
     (type_identifier)
-    (virtual_specifier)
+    (class_property_specifier)
     (field_declaration_list))
   (struct_specifier
     (type_identifier)
@@ -937,7 +937,7 @@ class A final : [[deprecated]] public B {};
     (field_declaration_list))
   (class_specifier
     (type_identifier)
-    (virtual_specifier)
+    (class_property_specifier)
     (base_class_clause
       (attribute_declaration
         (attribute


### PR DESCRIPTION
Btw the grammar reference links really should be https://eel.is/c++draft/gram