### PR TITLE
Make tree-sitter-cli check fail instead of continuing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
     message(FATAL_ERROR "TREE_SITTER_ABI_VERSION must be an integer")
 endif()
 
-find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI" REQUIRED)
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"


### PR DESCRIPTION
Currently, the tree-sitter-cli check passes instead of failing even when the executable is not found which leads to a build failure.

```
[1/5] Generating parser.c
FAILED: [code=127] tree-sitter-cpp/src/parser.c
cd tree-sitter-cpp && TREE_SITTER_CLI-NOTFOUND generate src/grammar.json --abi=14
/bin/sh: line 1: TREE_SITTER_CLI-NOTFOUND: command not found
```

Steps to reproduce:
1. Don't have the tree-sitter binary in $PATH/installed.
2. Go into the source directory of tree-sitter-cpp
3. Try to build the project with `cmake -G Ninja . && cmake --build .`
4. Build failure